### PR TITLE
Argparse

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -42,10 +42,10 @@ Besides what is below, OPTIONS... are passed on to nose."""
 
 if __name__ == "__main__":
     parser = ArgParser(formatter_class=argparse.RawTextHelpFormatter)
-    
+
     parser.add_argument('testfiles', nargs='*', default=None,
                         help=testfiles_help)
-    
+
     parser.add_argument('--fast', action='store_true',
                         help='exclude tests that are marked as slow')
     parser.add_argument('--cover', action='store_true',
@@ -56,15 +56,15 @@ if __name__ == "__main__":
         '-w', '--where', dest='dir', default='tests',
         help='search for tests in directory WHERE\n'
              '(this is exactly the "-w" or "--where" option of nose)')
-    
+
     args, unknown_args = parser.parse_known_args()
-    
+
     basenames = args.testfiles
     skip_slow = args.fast
     measure_coverage = args.cover
     require_nonlocaldir_tulip = args.outofsource
     tests_dir = args.dir
-    
+
     if require_nonlocaldir_tulip:
         # Scrub local directory from search path for modules
         import os
@@ -87,32 +87,32 @@ if __name__ == "__main__":
                               'besides in the local directory')
         else:
             raise()
-    
+
     argv = ["nosetests"]
     if skip_slow:
         argv.append("--attr=!slow")
-    
+
     if measure_coverage:
         argv.extend(["--with-coverage", "--cover-html", "--cover-package=tulip"])
-    
+
     available = []
     for dirpath, dirnames, filenames in walk(tests_dir):
         available.extend(filenames)
         break
-    
+
     testfiles = []
     excludefiles = []
     for basename in basenames:
         match = [f for f in available
                  if f.startswith(basename) and f.endswith('.py')]
-        
+
         if len(match) > 1:
             raise Exception('ambiguous base name: %s, matches: %s' %
                             (basename, match))
         elif match[0].endswith('_test.py'):
             testfiles.append(match[0])
             continue
-        
+
         if os.path.exists(os.path.join(tests_dir, basename + '_test.py')):
             testfiles.append(basename + '_test.py')
         elif basename[0] == '-':
@@ -122,18 +122,18 @@ if __name__ == "__main__":
                 argv.append(basename)
         else:
             argv.append(basename)
-    
+
     if testfiles and excludefiles:
         print("You can specify files to exclude or include, but not both.")
         print("Try calling it with \"-h\" flag.")
         exit(1)
-    
+
     if excludefiles:
         argv.append("--exclude=" + "|".join(excludefiles))
-    
+
     argv.extend(testfiles)
     argv += ["--where=" + tests_dir]
     argv.extend(unknown_args)
-    
+
     print('calling nose')
     nose.main(argv=argv + ["--verbosity=3", "--exe"])


### PR DESCRIPTION
Convert to use `argparse` in `run_tests.py` and some rudimentary automatic completion of partial test names, when there is no ambiguity. The motivation originally was to use `argcomplete`, but that proved too fragile, and there is a simpler solution w/o any extra dependencies.
