### PR TITLE
Use cvxopt option to silence newer versions of GLPK

### DIFF
--- a/tulip/abstract/find_controller.py
+++ b/tulip/abstract/find_controller.py
@@ -46,6 +46,8 @@ L{discretize}
 """
 import numpy as np
 from cvxopt import matrix, solvers
+solvers.options['msg_lev'] = 'GLP_MSG_OFF'
+
 import polytope as pc
 
 from .feasible import solve_feasible, createLM, _block_diag2


### PR DESCRIPTION
This follows a similar pull request made for the `polytope` package at tulip-control/polytope#11.  It is a simple change made in the commit 6384f106b88025e57496d09bb69cb6f8afe650a0 .  I have tested it in the following configuration:
- Ubuntu 14.04 on Linux x86_64
- Python 2.7.6
- `polytope` 0.1.0
- `cvxopt` 1.1.7
- GLPK 4.52.1, provided by the Debian package libglpk-dev 4.52.1-2build1
