### PR TITLE
Offer "slugs" via tulip.synth and use --jsonOutput tulip.interfaces.slugs

### DIFF
--- a/tulip/interfaces/slugs.py
+++ b/tulip/interfaces/slugs.py
@@ -63,7 +63,7 @@ def synthesize(spec):
         fin.write(s)
     logger.info('\n\n structured slugs:\n\n {struct}'.format(
         struct=struct) + '\n\n slugs in:\n\n {s}\n'.format(s=s))
-    options = [fin.name]
+    options = [fin.name, '--jsonOutput']
     realizable, out = _call_slugs(options)
     if not realizable:
         return None

--- a/tulip/interfaces/slugs.py
+++ b/tulip/interfaces/slugs.py
@@ -37,17 +37,18 @@ Relevant links:
 """
 from __future__ import absolute_import
 import logging
-logger = logging.getLogger(__name__)
 import json
 import os
 import subprocess
 import tempfile
 import networkx as nx
-import slugs
 from tulip.spec import GRSpec, translate
+# inline:
+#   import slugs
 
 
 BDD_FILE = 'strategy_bdd.txt'
+logger = logging.getLogger(__name__)
 
 
 def check_realizable(spec):
@@ -57,6 +58,7 @@ def check_realizable(spec):
 
     @return: True if realizable, False if not, or an error occurs.
     """
+    import slugs
     if isinstance(spec, GRSpec):
         struct = translate(spec, 'slugs')
     else:
@@ -81,6 +83,7 @@ def synthesize(spec, symbolic=False):
         struct = translate(spec, 'slugs')
     else:
         struct = spec
+    import slugs
     s = slugs.convert_to_slugsin(struct, True)
     with tempfile.NamedTemporaryFile(delete=False) as fin:
         fin.write(s)

--- a/tulip/interfaces/slugs.py
+++ b/tulip/interfaces/slugs.py
@@ -47,6 +47,27 @@ import slugs
 from tulip.spec import GRSpec, translate
 
 
+def check_realizable(spec):
+    """Decide realizability of specification.
+
+    Consult the documentation of L{synthesize} about parameters.
+
+    @return: True if realizable, False if not, or an error occurs.
+    """
+    if isinstance(spec, GRSpec):
+        struct = translate(spec, 'slugs')
+    else:
+        struct = spec
+    s = slugs.convert_to_slugsin(struct, True)
+    with tempfile.NamedTemporaryFile(delete=False) as fin:
+        fin.write(s)
+    logger.info('\n\n structured slugs:\n\n {struct}'.format(
+        struct=struct) + '\n\n slugs in:\n\n {s}\n'.format(s=s))
+    options = [fin.name, '--onlyRealizability']
+    realizable, out = _call_slugs(options)
+    return realizable
+
+
 def synthesize(spec):
     """Return strategy satisfying the specification C{spec}.
 

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -39,6 +39,11 @@ from tulip import transys
 from tulip.spec import GRSpec
 from tulip.interfaces import jtlv, gr1c
 
+# slugs is an optional dependency, so fail cleanly if it is missing.
+try:
+    from tulip.interfaces import slugs
+except ImportError:
+    slugs = None
 
 _hl = '\n' + 60 * '-'
 
@@ -968,7 +973,7 @@ def synthesize_many(specs, ts=None, ignore_init=None,
 
     @type bool_actions: C{set} of keys from C{ts}
 
-    @param solver: 'gr1c' or 'jtlv'
+    @param solver: 'gr1c' or 'slugs' or 'jtlv'
     @type solver: str
     """
     assert isinstance(ts, dict)
@@ -985,11 +990,16 @@ def synthesize_many(specs, ts=None, ignore_init=None,
                                  bool_actions=bool_act)
     if solver == 'gr1c':
         ctrl = gr1c.synthesize(specs)
+    elif solver == 'slugs':
+        if slugs is None:
+            raise ValueError('Import of slugs interface failed. ' +
+                             'Please verify installation of "slugs".')
+        ctrl = slugs.synthesize(specs)
     elif solver == 'jtlv':
         ctrl = jtlv.synthesize(specs)
     else:
         raise Exception('Unknown solver: ' + str(solver) + '. '
-                        'Available solvers: "jtlv" and "gr1c"')
+                        'Available solvers: "jtlv", "gr1c", and "slugs"')
     try:
         logger.debug('Mealy machine has: n = ' +
                      str(len(ctrl.states)) + ' states.')
@@ -1029,6 +1039,7 @@ def synthesize(
         what method to use, etc.  Currently recognized forms:
 
           - C{"gr1c"}: use gr1c for GR(1) synthesis via L{interfaces.gr1c}.
+          - C{"slugs"}: use slugs for GR(1) synthesis via L{interfaces.slugs}.
           - C{"jtlv"}: use JTLV for GR(1) synthesis via L{interfaces.jtlv}.
     @type specs: L{spec.GRSpec}
 
@@ -1087,11 +1098,16 @@ def synthesize(
         bool_actions)
     if option == 'gr1c':
         strategy = gr1c.synthesize(specs)
+    elif option == 'slugs':
+        if slugs is None:
+            raise ValueError('Import of slugs interface failed. ' +
+                             'Please verify installation of "slugs".')
+        strategy = slugs.synthesize(specs)
     elif option == 'jtlv':
         strategy = jtlv.synthesize(specs)
     else:
         raise Exception('Undefined synthesis option. ' +
-                        'Current options are "jtlv" and "gr1c"')
+                        'Current options are "jtlv", "gr1c", and "slugs"')
     ctrl = strategy2mealy(strategy, specs)
     try:
         logger.debug('Mealy machine has: n = ' +
@@ -1124,11 +1140,16 @@ def is_realizable(
         bool_states, bool_actions)
     if option == 'gr1c':
         r = gr1c.check_realizable(specs)
+    elif option == 'slugs':
+        if slugs is None:
+            raise ValueError('Import of slugs interface failed. ' +
+                             'Please verify installation of "slugs".')
+        r = slugs.check_realizable(specs)
     elif option == 'jtlv':
         r = jtlv.check_realizable(specs)
     else:
         raise Exception('Undefined synthesis option. ' +
-                        'Current options are "jtlv" and "gr1c"')
+                        'Current options are "jtlv", "gr1c", and "slugs"')
     if r:
         logger.debug('is realizable')
     else:


### PR DESCRIPTION
In this pull request, the function `synthesize()` in the `tulip.interfaces.slugs` is updated to use the switch --jsonOutput for getting output in JSON, and `slugs` is now available via several functions in `tulip.synth`. [slugs](https://github.com/LTLMoP/slugs) is now regarded as an optional dependency. For the time being, meeting the dependency is somewhat complicated. While we can hope to evenually persuade upstream to re-merge [pull request #8](https://github.com/LTLMoP/slugs/pull/8) and thus make installation easier, "slugs" will remain a dificult dependency because upstream offers neither releases nor versions.

## Build and install "slugs"

At time of writing, the remote HEAD points at [cd9959e54b093560a85833550780121844150b0f](https://github.com/LTLMoP/slugs/commit/cd9959e54b093560a85833550780121844150b0f). The instructions below are appropriate for Ubuntu 14.04 with Linux x86_64.
```shell
git clone https://github.com/LTLMoP/slugs.git
cd slugs
```
Extract the [CUDD 2.5.0](http://vlsi.colorado.edu/~fabio/CUDD/) tarball into the `lib` directory. Direct link is <ftp://vlsi.colorado.edu/pub/cudd-2.5.0.tar.gz>; the SHA-1 hash of the tarball is 7d0d8b4b03f5c1819fe77a82f3b947421a72d629. Then,
```shell
cd lib/cudd-2.5.0
patch Makefile ../../tools/CuddMakefile.patch
make
```
At this step, CUDD is built in the manner requested by the [slugs instructions](https://github.com/LTLMoP/slugs/blob/cd9959e54b093560a85833550780121844150b0f/README.md). Now,
```
cd ../..
cd src
qmake Tool.pro 
make
```
At this step, there is an executable file named `slugs` in the current directory. Place it somewhere on your system path. E.g., a non-root way to achieve this is
```shell
mkdir -p ~/opt/bin
cp slugs ~/opt/bin     
export PATH=$PATH:~/opt/bin
```
Now we will install the Python package `slugs`, which was introduced upstream via [pull request #8](https://github.com/LTLMoP/slugs/pull/8),
```shell
cd ..
git checkout 23a75790547e058552f0a3f76415b3400b3145f4
tools/StructuredSlugsParser
python setup.py install
```
where above you may want to activate a Python virtual environment before the `setup.py install` command; otherwise, the last line may need a prefix of `sudo`.

Now test the result by going to TuLiP and, using the code as of this pull request,
```shell
./run_tests.py slugs
```

After merging into master, I plan to incorporate the above building instructions into the TuLiP User's Guide. My motivation to not do so yet is that we may be able to eventually provide an easier process of meeting the dependency.
