### PR TITLE
interface to gr1py, a new tool for GR(1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy==1.7
 scipy
 
 # easy extras
+gr1py>=0.1.0
 pyparsing==2.0.3
 http://pydot.googlecode.com/files/pydot-1.0.28.tar.gz
 

--- a/tests/gr1pyint_test.py
+++ b/tests/gr1pyint_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""
+Tests for the interface with gr1py.
+"""
+import logging
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger('tulip.spec.lexyacc').setLevel(logging.WARNING)
+from nose.tools import raises
+import os
+from tulip.spec import GRSpec, translate
+from tulip.interfaces import gr1py
+
+
+class basic_test:
+    def setUp(self):
+        self.f_un = GRSpec(
+            env_vars="x", sys_vars="y",
+            env_init="x", env_prog="x",
+            sys_init="y", sys_safety=["y -> X(!y)", "!y -> X(y)"],
+            sys_prog="y && x")
+        self.dcounter = GRSpec(sys_vars={"y": (0, 5)}, sys_init=["y=0"],
+                               sys_prog=["y=0", "y=5"])
+
+    def tearDown(self):
+        self.f_un = None
+        self.dcounter = None
+
+    def test_check_realizable(self):
+        assert not gr1py.check_realizable(self.f_un,
+                                          init_option="ALL_ENV_EXIST_SYS_INIT")
+        self.f_un.sys_safety = []
+        assert gr1py.check_realizable(self.f_un,
+                                      init_option="ALL_ENV_EXIST_SYS_INIT")
+        assert gr1py.check_realizable(self.f_un,
+                                      init_option="ALL_INIT")
+
+        assert gr1py.check_realizable(self.dcounter,
+                                      init_option="ALL_ENV_EXIST_SYS_INIT")
+        self.dcounter.sys_init = []
+        assert gr1py.check_realizable(self.dcounter,
+                                      init_option="ALL_INIT")
+
+    def test_synthesize(self):
+        self.f_un.sys_safety = []  # Make it realizable
+        g = gr1py.synthesize(self.f_un,
+                             init_option="ALL_ENV_EXIST_SYS_INIT")
+        assert g is not None
+        assert len(g.env_vars) == 1 and 'x' in g.env_vars
+        assert len(g.sys_vars) == 1 and 'y' in g.sys_vars
+
+        g = gr1py.synthesize(self.dcounter,
+                             init_option="ALL_ENV_EXIST_SYS_INIT")
+        assert g is not None
+        assert len(g.env_vars) == 0
+        assert len(g.sys_vars) == 1 and 'y' in g.sys_vars
+        assert len(g) == 2, [g.nodes(data=True), g.edges(data=True)]

--- a/tulip/interfaces/gr1c.py
+++ b/tulip/interfaces/gr1c.py
@@ -339,9 +339,9 @@ def load_aut_json(x):
     symtab = autjs['ENV'] + autjs['SYS']
     A.env_vars = dict([v.items()[0] for v in autjs['ENV']])
     A.sys_vars = dict([v.items()[0] for v in autjs['SYS']])
-    for node_ID in autjs['nodes']:
-        node_label = dict([(k, v) for (k,v) in autjs['nodes'][node_ID].items()
-                           if k not in ('state', 'trans')])
+    omit = {'state', 'trans'}
+    for node_ID, d in autjs['nodes'].iteritems():
+        node_label = {k: d[k] for k in d if k not in omit}
         node_label['state'] = dict([(symtab[i].keys()[0],
                                      autjs['nodes'][node_ID]['state'][i])
                                     for i in range(len(symtab))])

--- a/tulip/interfaces/gr1c.py
+++ b/tulip/interfaces/gr1c.py
@@ -340,8 +340,8 @@ def load_aut_json(x):
     A.env_vars = dict([v.items()[0] for v in autjs['ENV']])
     A.sys_vars = dict([v.items()[0] for v in autjs['SYS']])
     for node_ID in autjs['nodes'].iterkeys():
-        node_label = dict([(k, autjs['nodes'][node_ID][k])
-                           for k in ('mode', 'rgrad')])
+        node_label = dict([(k, v) for (k,v) in autjs['nodes'][node_ID].items()
+                           if k not in ('state', 'trans')])
         node_label['state'] = dict([(symtab[i].keys()[0],
                                      autjs['nodes'][node_ID]['state'][i])
                                     for i in range(len(symtab))])

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -39,10 +39,13 @@ from __future__ import absolute_import
 
 import logging
 logger = logging.getLogger(__name__)
-import gr1py
-import gr1py.cli
 from tulip.spec import GRSpec, translate
 from tulip.interfaces.gr1c import load_aut_json
+try:
+    import gr1py
+    import gr1py.cli
+except ImportError:
+    gr1py = None
 
 
 _hl = 60 * '-'
@@ -72,6 +75,9 @@ def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
 
 
 def _spec_to_gr1py(spec):
+    if gr1py is None:
+        raise ValueError('Import of gr1py interface failed.\n'
+                         'Please verify installation of "gr1py".')
     s = translate(spec, 'gr1c')
     logger.info('\n{hl}\n gr1py input:\n {s}\n{hl}'.format(s=s, hl=_hl))
     tsys, exprtab = gr1py.cli.loads(s)

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -36,7 +36,7 @@ U{https://github.com/slivingston/gr1py}
 """
 from __future__ import absolute_import
 import logging
-from tulip.spec import GRSpec, translate
+from tulip.spec import translate
 from tulip.interfaces.gr1c import load_aut_json
 try:
     import gr1py

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -29,16 +29,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
-"""
-Interface to gr1py
+"""Interface to C{gr1py}.
 
 U{https://pypi.python.org/pypi/gr1py}
 U{https://github.com/slivingston/gr1py}
 """
 from __future__ import absolute_import
-
 import logging
-logger = logging.getLogger(__name__)
 from tulip.spec import GRSpec, translate
 from tulip.interfaces.gr1c import load_aut_json
 try:
@@ -48,6 +45,7 @@ except ImportError:
     gr1py = None
 
 
+logger = logging.getLogger(__name__)
 _hl = 60 * '-'
 
 

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2015 by California Institute of Technology
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the California Institute of Technology nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL CALTECH
+# OR THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+# USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+# OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+"""
+Interface to gr1py
+
+U{https://pypi.python.org/pypi/gr1py}
+U{https://github.com/slivingston/gr1py}
+"""
+from __future__ import absolute_import
+
+import logging
+logger = logging.getLogger(__name__)
+import gr1py
+import gr1py.cli
+from tulip.spec import GRSpec, translate
+from tulip.interfaces.gr1c import load_aut_json
+
+
+_hl = 60 * '-'
+
+
+def check_realizable(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
+    """Decide realizability of specification.
+
+    Consult the documentation of L{synthesize} about parameters.
+
+    @return: True if realizable, False if not, or an error occurs.
+    """
+    s = translate(spec, 'gr1c')
+    logger.info('\n{hl}\n gr1py input:\n {s}\n{hl}'.format(s=s, hl=_hl))
+    tsys, exprtab = gr1py.cli.loads(s)
+    return gr1py.solve.check_realizable(tsys, exprtab)
+
+def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
+    """Synthesize strategy realizing the given specification.
+
+    cf. L{tulip.interfaces.gr1c.synthesize}
+    """
+    s = translate(spec, 'gr1c')
+    logger.info('\n{hl}\n gr1py input:\n {s}\n{hl}'.format(s=s, hl=_hl))
+    tsys, exprtab = gr1py.cli.loads(s)
+    strategy = gr1py.solve.synthesize(tsys, exprtab)
+    if strategy is None:
+        return None
+    else:
+        return load_aut_json(gr1py.output.dump_json(tsys.symtab, strategy))

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -55,9 +55,7 @@ def check_realizable(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
 
     @return: True if realizable, False if not, or an error occurs.
     """
-    s = translate(spec, 'gr1c')
-    logger.info('\n{hl}\n gr1py input:\n {s}\n{hl}'.format(s=s, hl=_hl))
-    tsys, exprtab = gr1py.cli.loads(s)
+    tsys, exprtab = _spec_to_gr1py(spec)
     return gr1py.solve.check_realizable(tsys, exprtab)
 
 def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
@@ -65,11 +63,16 @@ def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
 
     cf. L{tulip.interfaces.gr1c.synthesize}
     """
-    s = translate(spec, 'gr1c')
-    logger.info('\n{hl}\n gr1py input:\n {s}\n{hl}'.format(s=s, hl=_hl))
-    tsys, exprtab = gr1py.cli.loads(s)
+    tsys, exprtab = _spec_to_gr1py(spec)
     strategy = gr1py.solve.synthesize(tsys, exprtab)
     if strategy is None:
         return None
     else:
         return load_aut_json(gr1py.output.dump_json(tsys.symtab, strategy))
+
+
+def _spec_to_gr1py(spec):
+    s = translate(spec, 'gr1c')
+    logger.info('\n{hl}\n gr1py input:\n {s}\n{hl}'.format(s=s, hl=_hl))
+    tsys, exprtab = gr1py.cli.loads(s)
+    return tsys, exprtab

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -68,8 +68,8 @@ def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
     strategy = gr1py.solve.synthesize(tsys, exprtab)
     if strategy is None:
         return None
-    else:
-        return load_aut_json(gr1py.output.dump_json(tsys.symtab, strategy))
+    s = gr1py.output.dump_json(tsys.symtab, strategy)
+    return load_aut_json(s)
 
 
 def _spec_to_gr1py(spec):

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -45,6 +45,12 @@ try:
 except ImportError:
     slugs = None
 
+# gr1py is an optional dependency, so fail cleanly if it is missing.
+try:
+    from tulip.interfaces import gr1py
+except ImportError:
+    gr1py = None
+
 _hl = '\n' + 60 * '-'
 
 
@@ -1040,6 +1046,7 @@ def synthesize(
 
           - C{"gr1c"}: use gr1c for GR(1) synthesis via L{interfaces.gr1c}.
           - C{"slugs"}: use slugs for GR(1) synthesis via L{interfaces.slugs}.
+          - C{"gr1py"}: use JTLV for GR(1) synthesis via L{interfaces.gr1py}.
           - C{"jtlv"}: use JTLV for GR(1) synthesis via L{interfaces.jtlv}.
     @type specs: L{spec.GRSpec}
 
@@ -1103,6 +1110,11 @@ def synthesize(
             raise ValueError('Import of slugs interface failed. ' +
                              'Please verify installation of "slugs".')
         strategy = slugs.synthesize(specs)
+    elif option == 'gr1py':
+        if gr1py is None:
+            raise ValueError('Import of gr1py interface failed. ' +
+                             'Please verify installation of "gr1py".')
+        strategy = gr1py.synthesize(specs)
     elif option == 'jtlv':
         strategy = jtlv.synthesize(specs)
         if isinstance(strategy, list):
@@ -1111,7 +1123,8 @@ def synthesize(
             strategy = None
     else:
         raise Exception('Undefined synthesis option. ' +
-                        'Current options are "jtlv", "gr1c", and "slugs"')
+                        'Current options are "jtlv", "gr1c", ' +
+                        '"slugs", and "gr1py"')
 
     # While the return values of the solver interfaces vary, we expect
     # here that strategy is either None to indicate unrealizable or a
@@ -1149,11 +1162,17 @@ def is_realizable(
             raise ValueError('Import of slugs interface failed. ' +
                              'Please verify installation of "slugs".')
         r = slugs.check_realizable(specs)
+    elif option == 'gr1py':
+        if gr1py is None:
+            raise ValueError('Import of gr1py interface failed. ' +
+                             'Please verify installation of "gr1py".')
+        r = gr1py.check_realizable(specs)
     elif option == 'jtlv':
         r = jtlv.check_realizable(specs)
     else:
         raise Exception('Undefined synthesis option. ' +
-                        'Current options are "jtlv", "gr1c", and "slugs"')
+                        'Current options are "jtlv", "gr1c", ' +
+                        '"slugs", and "gr1py"')
     if r:
         logger.debug('is realizable')
     else:

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -37,19 +37,13 @@ import copy
 import warnings
 from tulip import transys
 from tulip.spec import GRSpec
-from tulip.interfaces import jtlv, gr1c
-
+from tulip.interfaces import jtlv, gr1c, gr1py
 # slugs is an optional dependency, so fail cleanly if it is missing.
 try:
     from tulip.interfaces import slugs
 except ImportError:
     slugs = None
 
-# gr1py is an optional dependency, so fail cleanly if it is missing.
-try:
-    from tulip.interfaces import gr1py
-except ImportError:
-    gr1py = None
 
 _hl = '\n' + 60 * '-'
 
@@ -1111,9 +1105,6 @@ def synthesize(
                              'Please verify installation of "slugs".')
         strategy = slugs.synthesize(specs)
     elif option == 'gr1py':
-        if gr1py is None:
-            raise ValueError('Import of gr1py interface failed. ' +
-                             'Please verify installation of "gr1py".')
         strategy = gr1py.synthesize(specs)
     elif option == 'jtlv':
         strategy = jtlv.synthesize(specs)
@@ -1163,9 +1154,6 @@ def is_realizable(
                              'Please verify installation of "slugs".')
         r = slugs.check_realizable(specs)
     elif option == 'gr1py':
-        if gr1py is None:
-            raise ValueError('Import of gr1py interface failed. ' +
-                             'Please verify installation of "gr1py".')
         r = gr1py.check_realizable(specs)
     elif option == 'jtlv':
         r = jtlv.check_realizable(specs)


### PR DESCRIPTION
https://github.com/slivingston/gr1py
https://pypi.python.org/pypi/gr1py

"gr1py is an enumerative (or concrete) reactive synthesis tool for the GR(1) fragment of LTL. It is pure Python."

I recommend reviewing PR #133 first, because this is based on it. To run tests, try

    ./run_tests.py -f gr1py

Notes with comments:

* There is no reference to `gr1py` in the User's Guide nor among the checks of optional dependencies in `setup.py`. I recommend leaving it this way until we have experimented more with it, and possibly until the interface becomes more sophisticated.
* There is currently no declared preference about which versions of `gr1py` are supported. We should wait until the next release to decide it because `gr1py` could continue to progress between now and then. However, if you want to declare something now, use at least 0.1.0.
* A quick demonstration of the new interface is to modify `examples/robot_planning/continuous.py` to have `ctrl = synth.synthesize('gr1py', specs,` on line 101.