### PR TITLE
interface to symbolic Python solver for GR(1) games

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy==1.7
 scipy
 
 # easy extras
+omega>=0.0.4
 pyparsing==2.0.3
 http://pydot.googlecode.com/files/pydot-1.0.28.tar.gz
 

--- a/tests/omega_interface_test.py
+++ b/tests/omega_interface_test.py
@@ -1,0 +1,108 @@
+"""Tests for interface to `omega.games.gr1`."""
+import logging
+from tulip.spec import form
+from tulip.interfaces import omega as omega_int
+from tulip import synth
+
+
+logging.getLogger('astutils').setLevel('ERROR')
+logging.getLogger('omega.logic').setLevel('ERROR')
+
+
+def test_grspec_to_automaton():
+    sp = grspec_0()
+    a = omega_int._grspec_to_automaton(sp)
+    dvars = dict(x=dict(type='bool', owner='env', dom=None),
+                 y=dict(type='bool', owner='sys', dom=None))
+    assert a.vars == dvars, (a.vars, dvars)
+    r = a.action['env']
+    assert r == list(), r
+    r = a.action['sys']
+    assert r == ["x' -> y'"], r
+    r = a.win['<>[]']
+    assert r == ['!(!x)'], r
+    r = a.win['[]<>']
+    assert r == ['!y'], r
+
+
+def test_synthesis_bool():
+    sp = grspec_0()
+    h = omega_int.synthesize_enumerated_streett(sp)
+    g = synth.strategy2mealy(h, sp)
+    # fname = 'mealy.pdf'
+    # g.save(fname)
+    # pd = nx.to_pydot(g)
+    # pd.write_pdf(fname)
+    assert g is not None
+    assert len(g.inputs) == 1, g.inputs
+    assert 'x' in g.inputs, g.inputs
+    dom = g.inputs['x']
+    dom_ = {False, True}
+    assert dom == dom_, (dom, dom_)
+    assert len(g.outputs) == 1, g.outputs
+    assert 'y' in g.outputs, g.outputs
+    dom = g.outputs['y']
+    dom_ = {False, True}
+    assert dom == dom_, (dom, dom_)
+    assert len(g) == 5, [
+        g.nodes(data=True), g.edges(data=True)]
+
+
+def test_synthesis_fol():
+    sp = grspec_1()
+    h = omega_int.synthesize_enumerated_streett(sp)
+    g = synth.strategy2mealy(h, sp)
+    assert g is not None
+    assert len(g.inputs) == 1, g.inputs
+    assert 'x' in g.inputs, g.inputs
+    dom = g.inputs['x']
+    dom_ = set(xrange(5))
+    assert dom == dom_, (dom, dom_)
+    assert len(g.outputs) == 1, g.outputs
+    assert 'y' in g.outputs, g.outputs
+    dom = g.outputs['y']
+    dom_ = set(xrange(5))
+    assert dom == dom_, (dom, dom_)
+
+
+def test_synthesis_unrealizable():
+    sp = grspec_0()
+    sp.sys_prog = ['False']
+    h = omega_int.synthesize_enumerated_streett(sp)
+    assert h is None, h
+
+
+def test_is_circular_true():
+    f = form.GRSpec()
+    f.sys_vars['y'] = 'bool'
+    f.env_prog = ['y']
+    f.sys_prog = ['y']
+    triv = omega_int.is_circular(f)
+    assert triv, triv
+
+
+def test_is_circular_false():
+    f = form.GRSpec()
+    f.env_vars['x'] = 'bool'
+    f.env_prog = ['x']
+    f.sys_prog = ['x']
+    triv = omega_int.is_circular(f)
+    assert not triv, triv
+
+
+def grspec_0():
+    sp = form.GRSpec()
+    sp.env_vars = dict(x='boolean')
+    sp.sys_vars = dict(y='boolean')
+    sp.sys_safety = ["x' -> y'"]
+    sp.env_prog = ['!x']
+    sp.sys_prog = ['!y']
+    return sp
+
+
+def grspec_1():
+    sp = form.GRSpec()
+    sp.env_vars = dict(x=(0, 4))
+    sp.sys_vars = dict(y=(0, 4))
+    sp.sys_safety = ["x' = y'"]
+    return sp

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -20,7 +20,11 @@ except ImportError:
 
 
 def synthesize_enumerated_streett(spec):
-    """Return transducer enumerated as a graph."""
+    """Return transducer enumerated as a graph.
+
+    @type spec: `tulip.spec.form.GRSpec`
+    @rtype: `networkx.DiGraph`
+    """
     aut = _grspec_to_automaton(spec)
     sym.fill_blanks(aut)
     a = aut.build()
@@ -39,7 +43,11 @@ def synthesize_enumerated_streett(spec):
 
 
 def is_circular(spec):
-    """Return `True` if trivial winning set non-empty."""
+    """Return `True` if trivial winning set non-empty.
+
+    @type spec: `tulip.spec.form.GRSpec`
+    @rtype: `bool`
+    """
     aut = _grspec_to_automaton(spec)
     sym.fill_blanks(aut)
     triv, t = gr1.trivial_winning_set(aut)
@@ -47,7 +55,12 @@ def is_circular(spec):
 
 
 def _int_bounds(aut):
-    """Create care set for enumeration."""
+    """Create care set for enumeration.
+
+    @type aut: `omega.symbolic.symbolic.Automaton`
+    @return: node in a `dd.bdd.BDD`
+    @rtype: `int`
+    """
     int_types = {'int', 'saturating', 'modwrap'}
     bdd = aut.bdd
     u = bdd.true
@@ -66,7 +79,12 @@ def _int_bounds(aut):
 
 
 def _strategy_to_state_annotated(g, aut):
-    """Move annotation to `dict` as value of `'state'` key."""
+    """Move annotation to `dict` as value of `'state'` key.
+
+    @type g: `nx.DiGraph`
+    @type: aut: `omega.symbolic.symbolic.Automaton`
+    @rtype: `nx.DiGraph`
+    """
     h = nx.DiGraph()
     for u, d in g.nodes_iter(data=True):
         dvars = {k: d[k] for k in d if k in aut.vars}

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -1,0 +1,102 @@
+"""Interface to `omega` package.
+
+`omega` constructs symbolic transducers,
+represented as binary decision diagrams.
+This module applies enumeration,
+to return enumerated transducers.
+
+U{https://pypi.python.org/pypi/omega}
+"""
+from __future__ import absolute_import
+import networkx as nx
+try:
+    import omega
+    from omega.logic import bitvector as bv
+    from omega.games import gr1
+    from omega.symbolic import symbolic as sym
+    from omega.symbolic import enumeration as enum
+except ImportError:
+    omega = None
+
+
+def synthesize_enumerated_streett(spec):
+    """Return transducer enumerated as a graph."""
+    aut = _grspec_to_automaton(spec)
+    sym.fill_blanks(aut)
+    a = aut.build()
+    z, yij, xijk = gr1.solve_streett_game(a)
+    try:
+        t = gr1.make_streett_transducer(z, yij, xijk, a)
+    except AssertionError as e:
+        print(e)
+        return None
+    (u,) = t.action['sys']
+    care = _int_bounds(t)
+    g = enum.relation_to_graph(u, t, care_source=care,
+                               care_target=care)
+    h = _strategy_to_state_annotated(g, a)
+    return h
+
+
+def is_circular(spec):
+    """Return `True` if trivial winning set non-empty."""
+    aut = _grspec_to_automaton(spec)
+    sym.fill_blanks(aut)
+    triv, t = gr1.trivial_winning_set(aut)
+    return triv != t.bdd.false
+
+
+def _int_bounds(aut):
+    """Create care set for enumeration."""
+    int_types = {'int', 'saturating', 'modwrap'}
+    bdd = aut.bdd
+    u = bdd.true
+    for var, d in aut.vars.iteritems():
+        t = d['type']
+        if t == 'bool':
+            continue
+        assert t in int_types, t
+        dom = d['dom']
+        p, q = dom
+        e = "({p} <= {var}) & ({var} <= {q})".format(
+            p=p, q=q, var=var)
+        v = aut.add_expr(e)
+        u = bdd.apply('and', u, v)
+    return u
+
+
+def _strategy_to_state_annotated(g, aut):
+    """Move annotation to `dict` as value of `'state'` key."""
+    h = nx.DiGraph()
+    for u, d in g.nodes_iter(data=True):
+        dvars = {k: d[k] for k in d if k in aut.vars}
+        h.add_node(u, state=dvars)
+    for u, v in g.edges_iter():
+        h.add_edge(u, v)
+    return h
+
+
+def _grspec_to_automaton(g):
+    """Return `symbolic.Automaton` from `GRSpec`.
+
+    @type g: `tulip.spec.form.GRSpec`
+    @rtype: `omega.symbolic.symbolic.Automaton`
+    """
+    if omega is None:
+        raise ImportError(
+            'Failed to import package `omega`.')
+    a = sym.Automaton()
+    d = dict(g.env_vars)
+    d.update(g.sys_vars)
+    for k, v in d.iteritems():
+        if v == 'boolean':
+            v = 'bool'
+        d[k] = v
+    a.vars = bv.make_table(d, env_vars=g.env_vars)
+    a.init['env'] = list(g.env_init)
+    a.init['sys'] = list(g.sys_init)
+    a.action['env'] = list(g.env_safety)
+    a.action['sys'] = list(g.sys_safety)
+    a.win['<>[]'] = ['!({s})'.format(s=s) for s in g.env_prog]
+    a.win['[]<>'] = list(g.sys_prog)
+    return a

--- a/tulip/interfaces/slugs.py
+++ b/tulip/interfaces/slugs.py
@@ -42,8 +42,7 @@ import subprocess
 import tempfile
 import networkx as nx
 from tulip.spec import GRSpec, translate
-# inline:
-#   import slugs
+import slugs
 
 
 BDD_FILE = 'strategy_bdd.txt'
@@ -57,7 +56,6 @@ def check_realizable(spec):
 
     @return: True if realizable, False if not, or an error occurs.
     """
-    import slugs
     if isinstance(spec, GRSpec):
         struct = translate(spec, 'slugs')
     else:

--- a/tulip/interfaces/slugs.py
+++ b/tulip/interfaces/slugs.py
@@ -29,8 +29,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
-"""
-Interface to the slugs implementation of GR(1) synthesis.
+"""Interface to the slugs implementation of GR(1) synthesis.
 
 Relevant links:
   - U{slugs<https://github.com/LTLMoP/slugs>}

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -37,6 +37,7 @@ import warnings
 from tulip import transys
 from tulip.spec import GRSpec
 from tulip.interfaces import jtlv, gr1c
+from tulip.interfaces import omega as omega_int
 # optional dependencies
 try:
     from tulip.interfaces import slugs
@@ -1050,6 +1051,9 @@ def synthesize(
           - C{"gr1py"}: use gr1py via L{interfaces.gr1py}.
             Python, enumerative
 
+          - C{"omega"}: use omega via L{interfaces.omega}.
+            Python using C{dd} or Cython using CUDD, symbolic
+
           - C{"slugs"}: use slugs via L{interfaces.slugs}.
             C++ using CUDD, symbolic
 
@@ -1124,6 +1128,8 @@ def synthesize(
             raise ValueError('Import of gr1py interface failed. ' +
                              'Please verify installation of "gr1py".')
         strategy = gr1py.synthesize(specs)
+    elif option == 'omega':
+        strategy = omega_int.synthesize_enumerated_streett(specs)
     elif option == 'jtlv':
         strategy = jtlv.synthesize(specs)
         if isinstance(strategy, list):
@@ -1133,7 +1139,7 @@ def synthesize(
     else:
         raise Exception('Undefined synthesis option. ' +
                         'Current options are "gr1c", ' +
-                        '"slugs", "gr1py", and "jtlv".')
+                        '"slugs", "gr1py", "omega", and "jtlv".')
 
     # While the return values of the solver interfaces vary, we expect
     # here that strategy is either None to indicate unrealizable or a

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -37,14 +37,11 @@ import warnings
 from tulip import transys
 from tulip.spec import GRSpec
 from tulip.interfaces import jtlv, gr1c
-
-# slugs is an optional dependency, so fail cleanly if it is missing.
+# optional dependencies
 try:
     from tulip.interfaces import slugs
 except ImportError:
     slugs = None
-
-# gr1py is an optional dependency, so fail cleanly if it is missing.
 try:
     from tulip.interfaces import gr1py
 except ImportError:
@@ -1045,10 +1042,21 @@ def synthesize(
     @param option: Magic string that declares what tool to invoke,
         what method to use, etc.  Currently recognized forms:
 
-          - C{"gr1c"}: use gr1c for GR(1) synthesis via L{interfaces.gr1c}.
-          - C{"slugs"}: use slugs for GR(1) synthesis via L{interfaces.slugs}.
-          - C{"gr1py"}: use JTLV for GR(1) synthesis via L{interfaces.gr1py}.
-          - C{"jtlv"}: use JTLV for GR(1) synthesis via L{interfaces.jtlv}.
+        For GR(1) synthesis:
+
+          - C{"gr1c"}: use gr1c via L{interfaces.gr1c}.
+            written in C using CUDD, symbolic
+
+          - C{"gr1py"}: use gr1py via L{interfaces.gr1py}.
+            Python, enumerative
+
+          - C{"slugs"}: use slugs via L{interfaces.slugs}.
+            C++ using CUDD, symbolic
+
+          - C{"jtlv"}: use JTLV via L{interfaces.jtlv}.
+            Java, symbolic
+            (deprecated)
+
     @type specs: L{spec.GRSpec}
 
     @param env: A transition system describing the environment:
@@ -1124,8 +1132,8 @@ def synthesize(
             strategy = None
     else:
         raise Exception('Undefined synthesis option. ' +
-                        'Current options are "jtlv", "gr1c", ' +
-                        '"slugs", and "gr1py"')
+                        'Current options are "gr1c", ' +
+                        '"slugs", "gr1py", and "jtlv".')
 
     # While the return values of the solver interfaces vary, we expect
     # here that strategy is either None to indicate unrealizable or a

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -32,7 +32,6 @@
 """Interface to library of synthesis tools, e.g., JTLV, gr1c"""
 from __future__ import absolute_import
 import logging
-logger = logging.getLogger(__name__)
 import copy
 import warnings
 from tulip import transys
@@ -51,6 +50,8 @@ try:
 except ImportError:
     gr1py = None
 
+
+logger = logging.getLogger(__name__)
 _hl = '\n' + 60 * '-'
 
 


### PR DESCRIPTION
The solver is in [`omega.games.gr1`](https://github.com/johnyf/omega/blob/82752680d83d21c14c1f04af471f0e75d59dc99c/omega/games/gr1.py). Please install branch `master`, because `omega` 0.0.3 on PyPI does not work with [`dd >= 0.2.0`](https://github.com/johnyf/dd) (latest on PyPI).

The interface added to `tulip.synth` uses the Streett(1) solver of `omega.games.gr1`.
A Rabin(1) solver (= GR(1) counter-strategies) is also available and tested in `omega.games.gr1`.
It is not interfaced at this time, because `synth` does not return counter-strategies, but the addition of counter-strategies would be a small extension of `tulip.interfaces.omega`.

The function `tulip.interfaces.omega.is_circular` is added, to check whether the system can "trivially" win a game. Roughly, this means that, from some initial states, the system has a winning strategy for at least one persistence goal (= negated environment recurrence, as usually called in GR(1) games).
The `is_circular` function should allow easily diagnosing specifications with "circular" dependency of environment and system liveness goals.

The package `omega` and its dependencies are pure Python. This ensures portability, and for most relatively small problems, it should work fine. For large problems, `dd` interfaces to CUDD via Cython. With a try-except import in the module `omega.games.gr1` (to be added in the next release), it can use CUDD whenever present.