### PR TITLE
`omega` as default synthesizer, `GRSpec` attributes for synthesis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,14 @@ before_install:
   - pip install --ignore-installed --upgrade pip setuptools
   - pip install nose
   - pip install mock
+  ## install dd.cudd
+  - pip install dd
+  - pip download --no-dependencies dd>=0.4.0
+  - pip uninstall --yes dd
+  - tar xzf dd-*.tar.gz
+  - cd dd-*/
+  - python setup.py install --fetch --cudd
+  - cd ..
 
 install:
   - python setup.py sdist

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,59 +1,52 @@
 Installation
 ------------
 
-The latest release of TuLiP can be downloaded from `SourceForge
-<http://sourceforge.net/projects/tulip-control/files/>`_.
-
-TuLiP is designed to work with Python version 2.7, though it should also support
-Python version 3.2+.  The following additional Python packages are required to
-use the core functionality of TuLiP, and are installed automatically
-from PyPI when installing with ``pip install tulip``:
-
-* `NumPy <http://numpy.org/>`_
-* `SciPy <http://www.scipy.org/>`_
-* `NetworkX <http://networkx.lanl.gov/>`_
-* `pydot <https://github.com/erocarrera/pydot>`_
-* `PLY <http://www.dabeaz.com/ply/>`_
-* `polytope <https://pypi.python.org/pypi/polytope>`_ -- computations on and
-  plotting of convex polytopes
-
-Newcomers to scientific computing with Python should read
-:ref:`newbie-scipy-sec-label`.
-
-The default synthesis tool for GR(1) specifications is `gr1c
-<http://scottman.net/2012/gr1c>`_. Please install at least version 0.9.0. If you
-do not already have it, the introduction of `the manual of gr1c
-<https://tulip-control.github.io/gr1c/>`_ is a good place to begin.
-
-The following are optional dependencies, listed with a summary of dependent
-features:
-
-* `Matplotlib <http://matplotlib.org/>`_ -- many visualization features
-
-* `Graphviz <http://www.graphviz.org/>`_ -- generation of images (e.g., PNG
-  files) from dot code
-
-* `CVXOPT <http://cvxopt.org/>`_ -- construction and manipulation of discrete
-  abstractions
-
-For computing discrete abstractions from hybrid system descriptions, it is
-highly recommended---but not required---that you install `GLPK
-<http://www.gnu.org/s/glpk/>`_ (a fast linear programming solver). Note that you
-need to install GLPK *before* installing CVXOPT and follow the instructions in
-CVXOPT installation to ensure it recognizes GLPK as a solver. If you are a
-`MacPorts <http://www.macports.org/>`_ user, please note that MacPorts does not
-do this linking automatically.
-
-Once all of the above preparations are completed, you can install TuLiP::
-
-  $ pip install .
-
-TuLiP may instead be installed `from PyPI <https://pypi.python.org/pypi/tulip>`_::
+TuLiP works with Python version 2.7.
+Install it `from PyPI <https://pypi.python.org/pypi/tulip>`_ with::
 
   $ pip install tulip
 
-The above commands include checking of dependencies and automatic installation
-of missing Python packages. (N.B., not all dependencies are Python packages.)
+or from source::
+
+  $ pip install .
+
+``pip`` installs Python dependencies `automatically
+<https://pip.pypa.io/en/stable/reference/pip_install/#installation-order>`_.
+They are listed in ``install_requires`` within ``setup.py``.
+The only Python packages that you may want to install yourself,
+in order to link them properly are:
+
+* `NumPy <http://numpy.org/>`_
+* `SciPy <http://www.scipy.org/>`_
+
+The following are optional dependencies,
+listed with a summary of dependent features:
+
+* `Matplotlib <http://matplotlib.org/>`_ --
+  many visualization features
+
+* `Graphviz <http://www.graphviz.org/>`_ --
+  to plot graphs, for example discrete state machines
+
+* `CVXOPT <http://cvxopt.org/>`_ --
+  construction and manipulation of discrete abstractions
+
+* `GLPK <http://www.gnu.org/s/glpk/>`_ --
+  fast linear programming solver
+
+For computing discrete abstractions from hybrid system descriptions,
+it is highly recommended that you install both CVXOPT and GLPK.
+Note that you need to install GLPK *before* installing CVXOPT,
+and follow the `CVXOPT installation instructions
+<http://cvxopt.org/install/index.html>_`
+to link CVXOPT to GLPK.
+(If you use
+`MacPorts <http://www.macports.org/>`_,
+please note that MacPorts does not do this linking automatically.)
+
+The latest release of TuLiP can be downloaded also from
+`SourceForge
+<http://sourceforge.net/projects/tulip-control/files/>`_.
 
 
 .. _synt-tools-sec-label:
@@ -61,23 +54,34 @@ of missing Python packages. (N.B., not all dependencies are Python packages.)
 Alternative discrete synthesis tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While gr1c is required, as described in :doc:`install`, TuLiP can use other
-tools for formal synthesis. Those for which an interface is available are listed
-below. Also consult :doc:`specifications` concerning relevant syntax and
-summaries of the specification languages. Generally, direct interfaces are
-defined as modules in the subpackage ``tulip.interfaces``. However, these tools
-can be accessed indirectly by appropriately setting parameters for various
-functions in TuLiP, such as ``tulip.synth.synthesize()``.
+The default synthesis tool for GR(1) and Rabin(1) specifications is
+`omega <https://github.com/johnyf/omega>`_
+(installed by ``pip``).
+
+TuLiP can use other tools for formal synthesis.
+Those for which an interface is available are listed below.
+Also consult :doc:`specifications` concerning relevant syntax and
+summaries of the specification languages.
+Generally, direct interfaces are defined as modules in
+the subpackage ``tulip.interfaces``.
+However, these tools can be accessed indirectly,
+by appropriately setting parameters for various functions in TuLiP,
+such as ``tulip.synth.synthesize()``.
 
 These are *optional dependencies*. TuLiP is useful without having them
 installed, but certain functionality is only available when they are.
 
+
 GR(1)
 `````
 
-* `gr1py <https://github.com/slivingston/gr1py>`_
+* `gr1c <http://scottman.net/2012/gr1c>`_.
+  Please install at least version 0.9.0.
+  The introduction of
+  `the manual of gr1c <https://tulip-control.github.io/gr1c/>`_
+  is a good place to begin.
 
-* `omega <https://github.com/johnyf/omega>`_
+* `gr1py <https://github.com/slivingston/gr1py>`_
 
 * `slugs <https://github.com/LTLMoP/slugs>`_
 
@@ -116,6 +120,9 @@ for developers are provided in the :doc:`dev_guide`.
 New to Python?
 ~~~~~~~~~~~~~~
 
+Newcomers to scientific computing with Python should read
+:ref:`newbie-scipy-sec-label`.
+
 If you don't already use Python for scientific computing, consider using
 `Enthought Python Distribution (EPD) <http://enthought.com>`_ or `Enthought
 Canopy <https://www.enthought.com/products/canopy/>`_. This may make the
@@ -129,6 +136,7 @@ Alternatives to Enthought are listed on the `SciPy installation webpage
 
 EPD seems to work fine on most platforms but if you cannot get it to work, more
 alternative packages for Mac OS X and Microsoft Windows are mentioned below.
+
 
 .. _troubleshoot-sec-label:
 
@@ -212,13 +220,15 @@ NumPy, SciPy, CVXOPT, and Matplotlib for your system, consider trying
 The package of gr1c for Windows still cannot be found. But without this package,
 you can also run most TuLiP functions.
 
+
 Installing other Python dependencies
 ````````````````````````````````````
 
-The command ``pip install ...`` or ``easy_install ...`` will usually suffice. To
+The command ``pip install ...`` will usually suffice. To
 get `PLY <http://www.dabeaz.com/ply/>`_, try::
 
   $ pip install ply
+
 
 .. _venv-pydoc-sec-label:
 
@@ -250,6 +260,7 @@ it, try looking at the transys subpackage by entering::
 .. [#f1] On Unix systems, in particular GNU/Linux and Mac OS X, the
          terminal shell treats ``~`` as a special symbol representing
          the home directory of the current user.
+
 
 remote server installation
 ``````````````````````````

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -2,7 +2,8 @@ Installation
 ------------
 
 TuLiP works with Python version 2.7.
-Install it `from PyPI <https://pypi.python.org/pypi/tulip>`_ with::
+Install it with `pip <https://pip.pypa.io/en/stable/>`_
+from `PyPI <https://pypi.python.org/pypi/tulip>`_ with::
 
   $ pip install tulip
 
@@ -38,7 +39,7 @@ For computing discrete abstractions from hybrid system descriptions,
 it is highly recommended that you install both CVXOPT and GLPK.
 Note that you need to install GLPK *before* installing CVXOPT,
 and follow the `CVXOPT installation instructions
-<http://cvxopt.org/install/index.html>_`
+<http://cvxopt.org/install/index.html>`_
 to link CVXOPT to GLPK.
 (If you use
 `MacPorts <http://www.macports.org/>`_,

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -47,7 +47,7 @@ please note that MacPorts does not do this linking automatically.)
 
 The latest release of TuLiP can be downloaded also from
 `SourceForge
-<http://sourceforge.net/projects/tulip-control/files/>`_.
+<https://sourceforge.net/projects/tulip-control/files/>`_.
 
 
 .. _synt-tools-sec-label:

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -194,7 +194,7 @@ assumption that the specification is stutter invariant, we can describe the
 continuous dynamics by an LTL formula of the form
 
 .. math::
-   (v = c_i) \implies next(\bigvee_{j \text{ s.t. } c_i \to c_j} v = c_j),
+   (v = c_i) \implies \big(\bigvee_{j \text{ s.t. } c_i \to c_j} v' = c_j\big),
 
 where :math:`v` is a new discrete variable that describes in which cell
 the continuous state is.
@@ -240,15 +240,17 @@ while receiving externally triggered park signal.
 The specification of the robot is
 
 .. math::
-   \varphi = \square \diamond(\neg park) \implies (\square \diamond(s \in C_5)
+   \varphi = \square \diamond(\neg park)
+   \overset{sr}{\rightarrow}
+   (\square \diamond(s \in C_5)
    \wedge \square(park \implies \diamond(s \in C_0))).
 
 We cannot, however, deal with this specification directly since it is not in
 the form of GR(1).  An equivalent GR(1) specification of the above
 specification can be obtained by introducing an auxiliary discrete system
 variable :math:`X0reach,` initialized to `True`. The transition relation of
-:math:`X0reach,` is given by :math:`\square(\text{next}(X0reach) = (s \in
-C_0 \vee (X0reach \wedge \neg park))).`
+:math:`X0reach,` is given by
+:math:`\square(X0reach' = (s \in C_0 \vee (X0reach \wedge \neg park))).`
 
 To automatically synthesize a planner for this robot, we first import the
 necessary modules:
@@ -308,7 +310,7 @@ variable X0reach that is initialized to True and the specification
 :math:`\square(park \implies \diamond lot)` becomes
 
 .. math::
-     \square( (next(X0reach) = lot) \vee (X0reach \wedge \neg park))
+     \square( (X0reach' = lot) \vee (X0reach \wedge \neg park))
 
 The python code to implement this logic is given by:
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -12,69 +12,113 @@ simple discrete state controller for a robotic motion control system.
 
 Problem Formulation
 ```````````````````
-We consider a system that comprises the physical component, which we refer
-to as the plant, and the (potentially dynamic and not a priori known)
-environment in which the plant operates.  The system may contain both
-continuous (physical) and discrete (computational) components.  In summary,
-the problem we are interested in consists of
+We consider a physical system with given dynamics ("plant") and
+a controller that we are about to design ourselves.
+Both discrete-valued and continuous-valued variables may be used
+to describe the behavior of the system.
 
-  - discrete system state,
-  - continuous system state,
-  - (discrete) environment state, and
-  - specification.
+The environment can affect this system in two ways:
 
-Here, `discrete` state refers to the state that can take only a finite number
-of possible values while `continuous` state refers to the state that can take
-an infinite number of possible values, e.g., the position of the car.  The
-`environment` state is related to factors over which the system does not
-have control such as the position of an obstacle and the outside
+1. through discrete-valued variables
+2. through continuous-valued variables, understood as "disturbance" (noise).
+
+In summary, we study problems with the following elements:
+
+1. discrete-valued plant variables ("discrete state")
+2. continuous-valued plant variables ("continuous state")
+3. discrete-valued environment variables
+4. continuous-valued environment variables (disturbance)
+5. specification: formulae, including difference equations.
+
+Here, `discrete` state refers to variables that take only a finite number
+of possible values in the system behaviors that interest us,
+whereas `continuous` state refers to variables that can take
+an infinite number of possible values, e.g., the position of the car.
+
+The `environment` state is related to factors over which the controller
+has no authority, such as the position of an obstacle, or the outside
 temperature.  At any given time, the controller regulates the `system` (or
-`controlled`) state such that the specification is satisfied, given the
-current value of the environment variables and the previous system states.
-We say that the specification is `realizable` if for any possible behavior
-of the environment, such a controller exists, i.e., there exists a strategy
-for the system to satisfy the specification.
+`controlled`) state so as to satisfy the specification, given the
+current state of plant, environment, and the controller's "internal" state
+(memory -- think of a microprocessor's own memory).
+
+We say that a specification is `realizable` if there exists a controller
+exists that steers the plant in a way that, for all environment behaviors
+that we assume are possible to happen, the specification requirements
+on the plant are satisfied.
+
+We will use the following variables and functions of time to
+describe the continuous dynamics:
+
+1. :math:`t` a variable that represents discrete time
+2. :math:`s[t]` continuous state,
+3. :math:`u[t]` control input signal,
+4. :math:`d[t]` (uncontrolled) disturbance.
 
 Suppose the continuous state of the system evolves according to the
 following discrete-time linear time-invariant state space model:
-for :math:`t \in \{0,1,2,...\}`
+for :math:`t \in \{0, 1, 2, ...\}`
 
 .. math::
-   s[t+1]  =   As[t] + Bu[t] + Ed[t] + K \qquad
-   u[t] \in U,\, d[t] \in D,\, s[0] \in S,
+   s[t+1]  =   As[t] + Bu[t] + Ed[t] + K
    :label: dynamics
 
-where :math:`S \subseteq \mathbb{R}^n` is the state space of the continuous
-component of the system,
-:math:`U \subseteq \mathbb{R}^m` is the set of admissible control inputs,
-:math:`D \subseteq \mathbb{R}^p` is the set of exogenous disturbances and
-:math:`s[t], u[t], d[t]` are the continuous state, the control signal and
-the exogenous disturbance, respectively, at time :math:`t`.
+where:
+
+1. :math:`u[t] \in U`
+2. :math:`d[t] \in D`
+3. :math:`s[0] \in S`
+4. :math:`S \subseteq \mathbb{R}^n` are the continuous states
+    over which we study the system behavior,
+5. :math:`U \subseteq \mathbb{R}^m` is the set of admissible control inputs,
+6. :math:`D \subseteq \mathbb{R}^p` is the set of exogenous disturbances
+    that we assume are possible.
 
 We consider the case where the sets :math:`S, U, D` are bounded polytopes.
 
-Let :math:`\Pi` be a finite set of atomic propositions of system variables.
-Each of the atomic propositions in :math:`\Pi` essentially captures the
-states of interest.
-We consider the specification of the form
+
+The control design problem is solved in two phases.
+In the fist phase we abstract continuous-valued variables,
+replacing them with discrete-valued variables,
+with suitable constraints on their assumed and required behavior that
+faithfully represent what is going on at the continuous level.
+
+At the discrete level, a controller is synthesized from a specification
+expressed in temporal logic. The specification is written in what
+is known as an assume-guarantee form:
 
 .. math::
-   \varphi = \big(\varphi_{init} \wedge \varphi_e) \implies \varphi_s.
+   \varphi = \big(\varphi_{init} \wedge \varphi_e)
+   \overset{sr}{\rightarrow}
+   \varphi_s
    :label: spec
 
-Here, the assumption :math:`\varphi_{init}` on the initial condition of the system
-is a propositional formula built from :math:`\Pi.`
-The assumption :math:`\varphi_e` on the environment and the desired behavior
-:math:`\varphi_s` are LTL formulas built from :math:`\Pi.`
+where:
+
+1. :math:`\varphi_{init}` is an `assumption` on what initial states are possible
+2. :math:`\varphi_e` is an `assumption` about how the environment behaves,
+3. :math:`\varphi_s` is a `requirement` on the desired behavior we want,
+   and the physical constraints that have to be satisfied.
+
+These descriptions are not absolute. Some times, there are aspects of
+a problem that can be modeled in equivalent ways as either assumptions or
+requirements, using environment or system variables to represent them.
+This is a choice made during modeling of a problem with mathematics.
 
 As described in the :doc:`intro`, our approach to this reactive control
 system synthesis consists of the following main steps:
 
-   1. :ref:`Generate a proposition preserving partition of the continuous
-      state space. <ssec:prop-part>`
-   2. :ref:`Discretize the continuous state space based on the evolution of
-      the continuous state. <ssec:disc>`
-   3. :ref:`Digital design synthesis. <ssec:syn>`
+   1. Abstract the continuous-valued variables using discrete-valued
+      variables, by :ref:`generating a partition of the continuous states that
+      preserves the meaning of statements that appear in the specification.
+      <ssec:prop-part>`
+
+   2. Abstract the possible changes of continuous-valued variables,
+      by :ref:`discretizing the continuous dynamics,
+      based on solving reachability problems. <ssec:disc>`
+
+   3. :ref:`Digital design synthesis,<ssec:syn>`
+      by solving games of infinite duration.
 
 .. _ssec:prop-part:
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -219,10 +219,42 @@ possible behaviors of the environment.  This is done using the
     .. autofunction:: synth.synthesize
 	:noindex:
 
-The resulting output is a finite state machine (Mealy machine):
+More details about how Moore/Mealy capability,
+the assume-guarantee form of specification, and
+quantification of initial variable values are selected is described
+in the class :literal:`spec.GRSpec`:
+
+    .. autofunction:: spec.GRSpec
+
+The resulting output is a controller function that decides what values
+the controlled (discrete-valued) variables should take next.
+
+A `Moore` controller function cannot read the next
+values of (discrete-valued) environment variables before taking this
+decision, whereas a `Mealy` controller function can.
+Moore controllers are more realistic, and less prone to modeling errors,
+thus recommended.
 
     .. autofunction:: transys.machines.Transducer
 	:noindex:
+
+It should be noted that a temporal logic formula / property should be
+notionally distinguished from a synthesis problem:
+
+- You may write a formula to describe how a variable can change over time.
+  You may write even an assume-guarantee formula to describe an open-system
+  specification (i.e., how a system should behave in a certain environment).
+
+- A synthesis problem includes a definition of what the controller can do,
+  and whether the synthesizer should satisfy all initial conditions we wrote,
+  or is allowed to pick some initial conditions (thus synthesize the initial
+  conditions too).
+
+You may encounter this distinction if you give to ``synthesize`` both
+a transition system and temporal logic formulae.
+You may choose to define strategy capabilities (Moore/Mealy) as
+attributes to both, but these choices will have to agree,
+because one controller will be synthesized, not two.
 
 .. _ssec:ex1:
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -165,8 +165,9 @@ continuous state variables by the formula :math:`\displaystyle{\bigvee_{j
 
 Putting everything together, we now obtain a specification of the form in
 :eq:`spec` (see also :doc:`specifications`).  We can then use the GR(1) game
-implementation in `JTLV <http://jtlv.ysaar.net/>`_ or `gr1c
-<http://scottman.net/2012/gr1c>`_ to automatically synthesize a planner that
+implementation in `omega <https://github.com/johnyf/omega>`_ or
+`gr1c <http://scottman.net/2012/gr1c>`_
+to automatically synthesize a strategy that
 ensures the satisfaction of the specification, taking into account all the
 possible behaviors of the environment.  This is done using the
 :literal:`synth.synthesize` function:
@@ -184,7 +185,7 @@ The resulting output is a finite state machine (Mealy machine):
 Example 1: Discrete State Robot Motion Planning
 ```````````````````````````````````````````````
 This example is provided in examples/discrete.py.
-It illustrates the use of the gr1c module in synthesizing a planner
+It illustrates the use of the ``omega`` module in synthesizing a planner
 for a robot that only needs to make discrete decision.
 
 .. image:: robot_simple.*

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -190,8 +190,8 @@ state system indicates that from any continuous state :math:`s_0` that
 belongs to cell :math:`c_i`, there exists a sequence of control inputs
 :math:`u_0, u_1, \ldots, u_{N-1}` that takes the system to another
 continuous state :math:`s_{N}` in cell :math:`c_j`.  Hence, under the
-assumption that the specification is stutter invariant, we can describe the
-continuous dynamics by an LTL formula of the form
+assumption that the desired behavior is a stutter-invariant property,
+we can describe the continuous dynamics by an LTL formula of the form
 
 .. math::
    (v = c_i) \implies \big(\bigvee_{j \text{ s.t. } c_i \to c_j} v' = c_j\big),
@@ -208,9 +208,9 @@ continuous state variables by the formula :math:`\displaystyle{\bigvee_{j
 \text{ s.t. } c_j \models X_i} v = c_j}`.
 
 Putting everything together, we now obtain a specification of the form in
-:eq:`spec` (see also :doc:`specifications`).  We can then use the GR(1) game
-implementation in `omega <https://github.com/johnyf/omega>`_ or
-`gr1c <http://scottman.net/2012/gr1c>`_
+:eq:`spec` (see also :doc:`specifications`).  We can then use a GR(1) game
+solver, as those available in `omega <https://github.com/johnyf/omega>`_
+and `gr1c <http://scottman.net/2012/gr1c>`_
 to automatically synthesize a strategy that
 ensures the satisfaction of the specification, taking into account all the
 possible behaviors of the environment.  This is done using the

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -177,7 +177,7 @@ possible behaviors of the environment.  This is done using the
 
 The resulting output is a finite state machine (Mealy machine):
 
-    .. autofunction:: transys.FiniteStateMachine
+    .. autofunction:: transys.machines.Transducer
 	:noindex:
 
 .. _ssec:ex1:

--- a/examples/continuous.py
+++ b/examples/continuous.py
@@ -98,7 +98,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 
 # @synthesize_section@
 # Synthesize
-ctrl = synth.synthesize('gr1c', specs,
+ctrl = synth.synthesize('omega', specs,
                         sys=disc_dynamics.ts, ignore_sys_init=True)
 
 # Generate a graphical representation of the controller for viewing

--- a/examples/continuous.py
+++ b/examples/continuous.py
@@ -95,12 +95,14 @@ sys_prog |= {'X0reach'}
 # Create the specification
 specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
+specs.qinit = '\E \A'
 
 # @synthesize_section@
 # Synthesize
 ctrl = synth.synthesize('omega', specs,
                         sys=disc_dynamics.ts, ignore_sys_init=True)
 assert ctrl is not None, 'unrealizable'
+
 
 # Generate a graphical representation of the controller for viewing
 if not ctrl.save('continuous.png'):

--- a/examples/continuous.py
+++ b/examples/continuous.py
@@ -17,7 +17,6 @@ The dynamics is linear over a bounded set that is a polytope.
 # strings of the form @label@ are used for this purpose.
 
 import logging
-logging.basicConfig(level=logging.INFO)
 
 # @import_section@
 import numpy as np
@@ -28,6 +27,8 @@ from tulip.abstract import prop2part, discretize
 from tulip.abstract.plot import plot_partition
 # @import_section_end@
 
+
+logging.basicConfig(level=logging.WARNING)
 show = False
 
 # @dynamics_section@

--- a/examples/continuous.py
+++ b/examples/continuous.py
@@ -100,6 +100,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Synthesize
 ctrl = synth.synthesize('omega', specs,
                         sys=disc_dynamics.ts, ignore_sys_init=True)
+assert ctrl is not None, 'unrealizable'
 
 # Generate a graphical representation of the controller for viewing
 if not ctrl.save('continuous.png'):

--- a/examples/continuous.py
+++ b/examples/continuous.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
-"""
-This example is an extension of robot_discrete.py by including continuous
-dynamics with disturbances.
+"""Controller synthesis for system with continuous (linear) dynamics.
 
-Petter Nilsson (pettni@kth.se)
-August 14, 2011
-
-NO, system and cont. prop definitions based on TuLiP 1.x
-2 Jul, 2013
-NO, TuLiP 1.x discretization
-17 Jul, 2013
+This example is an extension of `robot_discrete.py`,
+by including continuous dynamics with disturbances.
+The dynamics is linear over a bounded set that is a polytope.
 """
-#
+# Petter Nilsson (pettni@kth.se)
+# August 14, 2011
+# NO, system and cont. prop definitions based on TuLiP 1.x
+# 2 Jul, 2013
+# NO, TuLiP 1.x discretization
+# 17 Jul, 2013
+
 # Note: This code is commented to allow components to be extracted into
 # the tutorial that is part of the users manual.  Comments containing
 # strings of the form @label@ are used for this purpose.

--- a/examples/continuous.py
+++ b/examples/continuous.py
@@ -16,11 +16,10 @@ The dynamics is linear over a bounded set that is a polytope.
 # the tutorial that is part of the users manual.  Comments containing
 # strings of the form @label@ are used for this purpose.
 
+# @import_section@
 import logging
 
-# @import_section@
 import numpy as np
-
 from tulip import spec, synth, hybrid
 from polytope import box2poly
 from tulip.abstract import prop2part, discretize

--- a/examples/controlled_switching.py
+++ b/examples/controlled_switching.py
@@ -1,20 +1,20 @@
-# This is an example to demonstrate how the output of abstracting a switched
-# system, where the dynamics are controlled through switching and
-# if multiple transitions are possible from a state in some mode,
-# then the system controls which one is taken.
+#!/usr/bin/env python
+"""Discrete synthesis from a dummy abstraction of controlled switched dynamics.
 
+This is an example to demonstrate how the output of abstracting a switched
+system, where the dynamics are controlled through switching and
+if multiple transitions are possible from a state in some mode,
+then the system controls which one is taken.
+
+We will assume, we have the 6 cell robot example.
+
+     +---+---+---+
+     | 3 | 4 | 5 |
+     +---+---+---+
+     | 0 | 1 | 2 |
+     +---+---+---+
+"""
 # NO, 26 Jul 2013.
-
-# We will assume, we have the 6 cell robot example.
-
-#
-#     +---+---+---+
-#     | 3 | 4 | 5 |
-#     +---+---+---+
-#     | 0 | 1 | 2 |
-#     +---+---+---+
-#
-
 from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp

--- a/examples/controlled_switching.py
+++ b/examples/controlled_switching.py
@@ -143,7 +143,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # At this point we can synthesize the controller using one of the available
 # methods.
 #
-ctrl = synth.synthesize('gr1c', specs, sys=sys_sws)
+ctrl = synth.synthesize('omega', specs, sys=sys_sws)
 
 # Generate a graphical representation of the controller for viewing
 if not ctrl.save('controlled_switching.png'):

--- a/examples/controlled_switching.py
+++ b/examples/controlled_switching.py
@@ -141,7 +141,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Controller synthesis
 #
 # At this point we can synthesize the controller using one of the available
-# methods.  Here we make use of gr1c.
+# methods.
 #
 ctrl = synth.synthesize('gr1c', specs, sys=sys_sws)
 

--- a/examples/controlled_switching.py
+++ b/examples/controlled_switching.py
@@ -139,6 +139,8 @@ sys_prog |= {'X0reach'}
 # Create the specification
 specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
+specs.moore = True
+specs.qinit = '\E \A'
 
 # Controller synthesis
 #

--- a/examples/controlled_switching.py
+++ b/examples/controlled_switching.py
@@ -15,9 +15,11 @@ We will assume, we have the 6 cell robot example.
      +---+---+---+
 """
 # NO, 26 Jul 2013.
-from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp
+from tulip import spec
+from tulip import synth
+from tulip import transys
 
 
 ###############################

--- a/examples/controlled_switching.py
+++ b/examples/controlled_switching.py
@@ -146,6 +146,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # methods.
 #
 ctrl = synth.synthesize('omega', specs, sys=sys_sws)
+assert ctrl is not None, 'unrealizable'
 
 # Generate a graphical representation of the controller for viewing
 if not ctrl.save('controlled_switching.png'):

--- a/examples/developer/fuel_tank/double_tank.py
+++ b/examples/developer/fuel_tank/double_tank.py
@@ -248,8 +248,10 @@ print("Starting synthesis")
 if os.name == "posix":
     start = os.times()[2]
 
+specs.moore = False
+specs.qinit = r'\A \E'
 ctrl = synth.synthesize(
-    'gr1c', specs, sys=sys_ts.ts, ignore_sys_init=True,
+    'omega', specs, sys=sys_ts.ts, ignore_sys_init=True,
     #action_vars=('u_in', 'act')
 )
 if os.name == "posix":

--- a/examples/developer/gr1_arbitrary_set.py
+++ b/examples/developer/gr1_arbitrary_set.py
@@ -1,5 +1,5 @@
 """
-Two examples for arbitrary finite domains with gr1c:
+Two examples for arbitrary finite domains:
 
     - one manually coded
     - one with arbitrary (unnumbered) sys TS states

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -127,6 +127,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 #
 # @synthesize@
 ctrl = synth.synthesize('omega', specs, sys=sys)
+assert ctrl is not None, 'unrealizable'
 # @synthesize_end@
 
 #

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-# discrete.py - example using transition system dynamics
-#
-# RMM, 20 Jul 2013
-"""
+"""Example using transition system dynamics.
+
 This example illustrates the use of TuLiP to synthesize a reactive
 controller for system whose dynamics are described by a discrete
 transition system.
 """
+# RMM, 20 Jul 2013
 #
 # Note: This code is commented to allow components to be extracted into
 # the tutorial that is part of the users manual.  Comments containing

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -126,7 +126,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # methods.
 #
 # @synthesize@
-ctrl = synth.synthesize('gr1c', specs, sys=sys)
+ctrl = synth.synthesize('omega', specs, sys=sys)
 # @synthesize_end@
 
 #

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -22,7 +22,7 @@ from tulip import transys, spec, synth
 logging.basicConfig(level=logging.WARNING)
 logging.getLogger('tulip.spec.lexyacc').setLevel(logging.WARNING)
 logging.getLogger('tulip.synth').setLevel(logging.WARNING)
-logging.getLogger('tulip.interfaces.gr1c').setLevel(logging.WARNING)
+logging.getLogger('tulip.interfaces.omega').setLevel(logging.WARNING)
 
 
 #

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -13,15 +13,18 @@ transition system.
 #
 
 import logging
-logging.basicConfig(level=logging.INFO)
-logging.getLogger('tulip.spec.lexyacc').setLevel(logging.WARNING)
-logging.getLogger('tulip.synth').setLevel(logging.DEBUG)
-logging.getLogger('tulip.interfaces.gr1c').setLevel(logging.DEBUG - 3)
 
 # @import_section@
 # Import the packages that we need
 from tulip import transys, spec, synth
 # @import_section_end@
+
+
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger('tulip.spec.lexyacc').setLevel(logging.WARNING)
+logging.getLogger('tulip.synth').setLevel(logging.WARNING)
+logging.getLogger('tulip.interfaces.gr1c').setLevel(logging.WARNING)
+
 
 #
 # System dynamics

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -123,7 +123,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Controller synthesis
 #
 # At this point we can synthesize the controller using one of the available
-# methods.  Here we make use of gr1c.
+# methods.
 #
 # @synthesize@
 ctrl = synth.synthesize('gr1c', specs, sys=sys)

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -14,6 +14,7 @@ transition system.
 # @import_section@
 # Import the packages that we need
 import logging
+
 from tulip import transys, spec, synth
 # @import_section_end@
 
@@ -126,6 +127,13 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # methods.
 #
 # @synthesize@
+# Moore machines
+# controller reads `env_vars, sys_vars`, but not next `env_vars` values
+specs.moore = True
+# synthesizer should find initial system values that satisfy
+# `env_init /\ sys_init` and work, for every environment variable
+# initial values that satisfy `env_init`.
+specs.qinit = '\E \A'
 ctrl = synth.synthesize('omega', specs, sys=sys)
 assert ctrl is not None, 'unrealizable'
 # @synthesize_end@

--- a/examples/discrete.py
+++ b/examples/discrete.py
@@ -10,12 +10,10 @@ transition system.
 # Note: This code is commented to allow components to be extracted into
 # the tutorial that is part of the users manual.  Comments containing
 # strings of the form @label@ are used for this purpose.
-#
-
-import logging
 
 # @import_section@
 # Import the packages that we need
+import logging
 from tulip import transys, spec, synth
 # @import_section_end@
 

--- a/examples/environment_switching.py
+++ b/examples/environment_switching.py
@@ -1,19 +1,19 @@
-# This is an example to demonstrate how the output of the TuLiP discretization
-# for a system with uncontrollable switching (i.e., modes are controlled by the
-# environment) might look like.
+#!/usr/bin/env python
+"""Discrete synthesis from a dummy abstraction with uncontrolled switching.
 
+This is an example to demonstrate how the output of the TuLiP discretization
+for a system with uncontrollable switching (i.e., modes are controlled by the
+environment) might look like.
+
+We will assume, we have the 6 cell robot example.
+
+     +---+---+---+
+     | 3 | 4 | 5 |
+     +---+---+---+
+     | 0 | 1 | 2 |
+     +---+---+---+
+"""
 # NO, 26 Jul 2013.
-
-# We will assume, we have the 6 cell robot example.
-
-#
-#     +---+---+---+
-#     | 3 | 4 | 5 |
-#     +---+---+---+
-#     | 0 | 1 | 2 |
-#     +---+---+---+
-#
-
 from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp

--- a/examples/environment_switching.py
+++ b/examples/environment_switching.py
@@ -126,6 +126,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # methods.
 #
 ctrl = synth.synthesize('omega', specs, sys=sys_swe, ignore_sys_init=True)
+assert ctrl is not None, 'unrealizable'
 
 # @plot_print@
 if not ctrl.save('environment_switching.png'):

--- a/examples/environment_switching.py
+++ b/examples/environment_switching.py
@@ -122,7 +122,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # At this point we can synthesize the controller using one of the available
 # methods.
 #
-ctrl = synth.synthesize('gr1c', specs, sys=sys_swe, ignore_sys_init=True)
+ctrl = synth.synthesize('omega', specs, sys=sys_swe, ignore_sys_init=True)
 
 # @plot_print@
 if not ctrl.save('environment_switching.png'):

--- a/examples/environment_switching.py
+++ b/examples/environment_switching.py
@@ -14,9 +14,12 @@ We will assume, we have the 6 cell robot example.
      +---+---+---+
 """
 # NO, 26 Jul 2013.
-from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp
+from tulip import spec
+from tulip import synth
+from tulip import transys
+
 
 ###########################################
 # Environment switched system with 2 modes:

--- a/examples/environment_switching.py
+++ b/examples/environment_switching.py
@@ -119,6 +119,11 @@ sys_prog |= {'X0reach'}
 # Create the specification
 specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
+# controller decides based on current values `env_vars, sys_vars`
+# and next values `env_vars'`. A controller with this
+# information flow is known as Mealy.
+specs.moore = False
+specs.qinit = '\A \E'
 
 # Controller synthesis
 #

--- a/examples/environment_switching.py
+++ b/examples/environment_switching.py
@@ -120,7 +120,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Controller synthesis
 #
 # At this point we can synthesize the controller using one of the available
-# methods.  Here we make use of gr1c.
+# methods.
 #
 ctrl = synth.synthesize('gr1c', specs, sys=sys_swe, ignore_sys_init=True)
 

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -108,7 +108,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # At this point we can synthesize the controller
 # using one of the available methods.
 #
-mealy_controller = synth.synthesize('gr1c', specs)
+mealy_controller = synth.synthesize('omega', specs)
 
 # Generate a graphical representation of the controller for viewing,
 # or a textual representation if pydot is missing.

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
-# gr1.py - example of direct GR(1) specification,
-#          using only boolean variables.
-#
-# 21 Jul 2013, Richard M. Murray (murray@cds.caltech.edu)
-"""
+"""Example of direct GR(1) specification, using only boolean variables.
+
 This example illustrates the use of TuLiP to synthesize a reactive
 controller for a GR(1) specification.  We code the specification
 directly in GR(1) form and then use TuLiP to synthesize a reactive
@@ -34,6 +31,7 @@ We must convert this specification into GR(1) form:
   env_init && []env_safe && []<>env_prog_1 && ... && []<>env_prog_m ->
       sys_init && []sys_safe && []<>sys_prog_1 && ... && []<>sys_prog_n
 """
+# 21 Jul 2013, Richard M. Murray (murray@cds.caltech.edu)
 import logging
 logging.basicConfig(level=logging.DEBUG)
 

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -107,6 +107,16 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 #
 # Controller synthesis
 #
+# The controller decides based on current variable values only,
+# without knowing yet the next values that environment variables take.
+# A controller with this information flow is known as Moore.
+specs.moore = True
+# Ask the synthesizer to find initial values for system variables
+# that, for each initial values that environment variables can
+# take and satisfy `env_init`, the initial state satisfies
+# `env_init /\ sys_init`.
+specs.qinit = '\E \A'  # i.e., "there exist sys_vars: forall sys_vars"
+
 # At this point we can synthesize the controller
 # using one of the available methods.
 strategy = synth.synthesize('omega', specs)

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -107,7 +107,6 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 #
 # At this point we can synthesize the controller
 # using one of the available methods.
-# Here we make use of gr1c.
 #
 mealy_controller = synth.synthesize('gr1c', specs)
 

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -110,7 +110,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # At this point we can synthesize the controller
 # using one of the available methods.
 strategy = synth.synthesize('omega', specs)
-#
+assert strategy is not None, 'unrealizable'
 
 # Generate a graphical representation of the controller for viewing,
 # or a textual representation if pydot is missing.

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -33,11 +33,14 @@ We must convert this specification into GR(1) form:
 """
 # 21 Jul 2013, Richard M. Murray (murray@cds.caltech.edu)
 import logging
-logging.basicConfig(level=logging.DEBUG)
 
 # Import the packages that we need
 from tulip import spec, synth
 from tulip.transys import machines
+
+
+logging.basicConfig(level=logging.WARNING)
+
 
 #
 # Environment specification

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -32,10 +32,11 @@ We must convert this specification into GR(1) form:
       sys_init && []sys_safe && []<>sys_prog_1 && ... && []<>sys_prog_n
 """
 # 21 Jul 2013, Richard M. Murray (murray@cds.caltech.edu)
+# Import the packages that we need
 import logging
 
-# Import the packages that we need
-from tulip import spec, synth
+from tulip import spec
+from tulip import synth
 from tulip.transys import machines
 
 

--- a/examples/gr1.py
+++ b/examples/gr1.py
@@ -109,14 +109,14 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 #
 # At this point we can synthesize the controller
 # using one of the available methods.
+strategy = synth.synthesize('omega', specs)
 #
-mealy_controller = synth.synthesize('omega', specs)
 
 # Generate a graphical representation of the controller for viewing,
 # or a textual representation if pydot is missing.
-if not mealy_controller.save('gr1.png'):
-    print(mealy_controller)
+if not strategy.save('gr1.png'):
+    print(strategy)
 
 # simulate
-print(mealy_controller)
-machines.random_run(mealy_controller, N=10)
+print(strategy)
+machines.random_run(strategy, N=10)

--- a/examples/gr1_set.py
+++ b/examples/gr1_set.py
@@ -103,7 +103,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Controller synthesis
 #
 # At this point we can synthesize the controller using one of the available
-# methods.  Here we make use of gr1c.
+# methods.
 #
 
 ctrl = synth.synthesize('gr1c', specs)

--- a/examples/gr1_set.py
+++ b/examples/gr1_set.py
@@ -34,7 +34,8 @@ We must convert this specification into GR(1) form:
 # 21 Jul 2013, Richard M. Murray (murray@cds.caltech.edu)
 
 # Import the packages that we need
-from tulip import spec, synth
+from tulip import spec
+from tulip import synth
 
 
 #

--- a/examples/gr1_set.py
+++ b/examples/gr1_set.py
@@ -106,6 +106,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 #
 
 ctrl = synth.synthesize('omega', specs)
+assert ctrl is not None, 'unrealizable'
 
 
 # Generate a graphical representation of the controller for viewing

--- a/examples/gr1_set.py
+++ b/examples/gr1_set.py
@@ -97,6 +97,7 @@ sys_prog |= {'X0reach', 'loc=5'}
 # Create a GR(1) specification
 specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
+specs.qinit = '\E \A'  # Moore initial condition synthesized too
 
 #
 # Controller synthesis

--- a/examples/gr1_set.py
+++ b/examples/gr1_set.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
-# gr1_set.py - example of direct GR(1) specification,
-#              using an integer-valued variable to model location.
-#
-# 21 Jul 2013, Richard M. Murray (murray@cds.caltech.edu)
-"""
+"""Direct GR(1) specification, with integer-valued variable to model location.
+
 This example illustrates the use of TuLiP to synthesize a reactive
 controller for a GR(1) specification.  We code the specification
 directly in GR(1) form and then use TuLiP to synthesize a reactive
@@ -34,6 +31,7 @@ We must convert this specification into GR(1) form:
   env_init && []env_safe && []<>env_prog_1 && ... && []<>env_prog_m ->
       sys_init && []sys_safe && []<>sys_prog_1 && ... && []<>sys_prog_n
 """
+# 21 Jul 2013, Richard M. Murray (murray@cds.caltech.edu)
 
 # Import the packages that we need
 from tulip import spec, synth

--- a/examples/gr1_set.py
+++ b/examples/gr1_set.py
@@ -106,7 +106,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # methods.
 #
 
-ctrl = synth.synthesize('gr1c', specs)
+ctrl = synth.synthesize('omega', specs)
 
 
 # Generate a graphical representation of the controller for viewing

--- a/examples/gridworlds/solverand.py
+++ b/examples/gridworlds/solverand.py
@@ -31,9 +31,12 @@ Z = gw.random_world((height, width),
                     num_goals=2)
 print(Z)
 
-if not synth.is_realizable('gr1c', Z.spec()):
+spc = Z.spec()
+spc.moore = False
+spc.qinit = r'\A \E'
+if not synth.is_realizable('omega', spc):
     print("Not realizable.")
 else:
-    ctrl = synth.synthesize('gr1c', Z.spec())
+    ctrl = synth.synthesize('omega', spc)
     if not ctrl.save('ctrl-solverand.svg'):
         print(ctrl)

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -164,6 +164,6 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # methods.
 #
 ctrl = synth.synthesize('omega', specs, sys=sys_hyb, ignore_sys_init=True)
-
+assert ctrl is not None, 'unrealizable'
 if not ctrl.save('hybrid.png'):
     print(ctrl)

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -154,9 +154,16 @@ sys_safe |= {'(sys_actions = "gear1" && env_actions = "slippery") -> ' +
 # to use int actions:
 # sys_safe |= {'((act = gear1) && (eact = slippery)) -> X (act = gear1)'}
 
-# Create the specification
+
+# Create the specification formulae
 specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
+# Mealy controller (can decide based on `env_vars'`)
+specs.moore = False
+# Pick initial values for system variables that
+# work for all assumed environment initial conditions.
+specs.qinit = '\E \A'
+
 
 # Controller synthesis
 #

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -157,7 +157,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # At this point we can synthesize the controller using one of the available
 # methods.
 #
-ctrl = synth.synthesize('gr1c', specs, sys=sys_hyb, ignore_sys_init=True)
+ctrl = synth.synthesize('omega', specs, sys=sys_hyb, ignore_sys_init=True)
 
 if not ctrl.save('hybrid.png'):
     print(ctrl)

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -155,7 +155,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Controller synthesis
 #
 # At this point we can synthesize the controller using one of the available
-# methods.  Here we make use of gr1c.
+# methods.
 #
 ctrl = synth.synthesize('gr1c', specs, sys=sys_hyb, ignore_sys_init=True)
 

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -21,9 +21,11 @@ We will assume, we have the 6 cell robot example.
 # NO, 26 Jul 2013.
 import logging
 
-from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp
+from tulip import spec
+from tulip import synth
+from tulip import transys
 
 
 logging.basicConfig(level=logging.WARNING)

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -1,22 +1,24 @@
-# This is an example to demonstrate how the output of a discretization algorithm
-# that abstracts a switched system, where the mode of the system depends on a
-# combination of environment and system controlled variables, might look like.
-# We assume within each mode the control authority is rich enough to establish
-# deterministic reachability relations through the use of low-level continuous
-# inputs.
+#!/usr/bin/env python
+"""Discrete synthesis from a dummy abstraction with mixed switching.
 
+This is an example to demonstrate how the output of a discretization algorithm
+that abstracts a switched system might look like,
+where the mode of the system depends on a combination of
+environment and system controlled variables.
+
+We assume within each mode that the control authority is rich enough to
+establish deterministic reachability relations,
+through the use of low-level continuous inputs.
+
+We will assume, we have the 6 cell robot example.
+
+     +---+---+---+
+     | 3 | 4 | 5 |
+     +---+---+---+
+     | 0 | 1 | 2 |
+     +---+---+---+
+"""
 # NO, 26 Jul 2013.
-
-# We will assume, we have the 6 cell robot example.
-
-#
-#     +---+---+---+
-#     | 3 | 4 | 5 |
-#     +---+---+---+
-#     | 0 | 1 | 2 |
-#     +---+---+---+
-#
-
 import logging
 logging.basicConfig(level=logging.INFO)
 logging.getLogger('tulip.spec').setLevel(logging.ERROR)

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -20,13 +20,15 @@ We will assume, we have the 6 cell robot example.
 """
 # NO, 26 Jul 2013.
 import logging
-logging.basicConfig(level=logging.INFO)
-logging.getLogger('tulip.spec').setLevel(logging.ERROR)
-logging.getLogger('tulip.synth').setLevel(logging.DEBUG)
 
 from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp
+
+
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger('tulip.spec').setLevel(logging.WARNING)
+logging.getLogger('tulip.synth').setLevel(logging.WARNING)
 
 
 ###########################################

--- a/examples/only_mode_controlled.py
+++ b/examples/only_mode_controlled.py
@@ -147,7 +147,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # At this point we can synthesize the controller using one of the available
 # methods.
 #
-ctrl = synth.synthesize('gr1c', specs, env=env_sws)
+ctrl = synth.synthesize('omega', specs, env=env_sws)
 
 # Generate a graphical representation of the controller for viewing
 if not ctrl.save('only_mode_controlled.png'):

--- a/examples/only_mode_controlled.py
+++ b/examples/only_mode_controlled.py
@@ -1,19 +1,19 @@
-# This is an example to demonstrate how the output of abstracting a switched
-# system, where the only control over the dynamics is through mode switching
-# might look like.
+#!/usr/bin/env python
+"""Discrete synthesis from a dummy abstraction of switched dynamics.
 
+This is an example to demonstrate how the output of abstracting a switched
+system, where the only control over the dynamics is through mode switching,
+might look like.
+
+We will assume, we have the 6 cell robot example.
+
+     +---+---+---+
+     | 3 | 4 | 5 |
+     +---+---+---+
+     | 0 | 1 | 2 |
+     +---+---+---+
+"""
 # NO, 26 Jul 2013.
-
-# We will assume, we have the 6 cell robot example.
-
-#
-#     +---+---+---+
-#     | 3 | 4 | 5 |
-#     +---+---+---+
-#     | 0 | 1 | 2 |
-#     +---+---+---+
-#
-
 from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp

--- a/examples/only_mode_controlled.py
+++ b/examples/only_mode_controlled.py
@@ -14,10 +14,11 @@ We will assume, we have the 6 cell robot example.
      +---+---+---+
 """
 # NO, 26 Jul 2013.
-from tulip import spec, synth, transys
 import numpy as np
 from scipy import sparse as sp
-
+from tulip import spec
+from tulip import synth
+from tulip import transys
 
 ###############################
 # Switched system with 4 modes:

--- a/examples/only_mode_controlled.py
+++ b/examples/only_mode_controlled.py
@@ -142,6 +142,7 @@ sys_prog |= {'X0reach'}
 # Create the specification
 specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
+specs.qinit = '\E \A'
 
 # Controller synthesis
 #

--- a/examples/only_mode_controlled.py
+++ b/examples/only_mode_controlled.py
@@ -149,6 +149,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # methods.
 #
 ctrl = synth.synthesize('omega', specs, env=env_sws)
+assert ctrl is not None, 'unrealizable'
 
 # Generate a graphical representation of the controller for viewing
 if not ctrl.save('only_mode_controlled.png'):

--- a/examples/only_mode_controlled.py
+++ b/examples/only_mode_controlled.py
@@ -145,7 +145,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Controller synthesis
 #
 # At this point we can synthesize the controller using one of the available
-# methods.  Here we make use of gr1c.
+# methods.
 #
 ctrl = synth.synthesize('gr1c', specs, env=env_sws)
 

--- a/examples/pwa.py
+++ b/examples/pwa.py
@@ -132,6 +132,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
 # Synthesize
 ctrl = synth.synthesize('omega', specs,
                         sys=disc_dynamics.ts, ignore_sys_init=True)
+assert ctrl is not None, 'unrealizable'
 if plotting:
     ax = plot_strategy(disc_dynamics, ctrl)
     ax.figure.savefig('pwa_proj_mealy.pdf')

--- a/examples/pwa.py
+++ b/examples/pwa.py
@@ -4,12 +4,15 @@
 # by Petter Nilsson and Nok Wongpiromsarn.
 # Necmiye Ozay, August 26, 2012
 import numpy as np
-
-from tulip import spec, synth
-from tulip.hybrid import LtiSysDyn, PwaSysDyn
 from polytope import box2poly
-from tulip.abstract import prop2part, discretize
+from tulip.abstract import discretize
+from tulip.abstract import prop2part
 from tulip.abstract.plot import plot_strategy
+from tulip.hybrid import LtiSysDyn
+from tulip.hybrid import PwaSysDyn
+from tulip import spec
+from tulip import synth
+
 
 plotting = True
 

--- a/examples/pwa.py
+++ b/examples/pwa.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python
-"""
-This example is an extension of the robot_continuous.py
-code by Petter Nilsson and Nok Wongpiromsarn.
-
-It demonstrates  the use of TuLiP for systems with
-piecewise affine dynamics.
-
-Necmiye Ozay, August 26, 2012
-"""
+"""Controller synthesis for system with piecewise-affine continuous dynamics."""
+# This example is an extension of `robot_continuous.py`
+# by Petter Nilsson and Nok Wongpiromsarn.
+# Necmiye Ozay, August 26, 2012
 import numpy as np
 
 from tulip import spec, synth

--- a/examples/pwa.py
+++ b/examples/pwa.py
@@ -80,8 +80,9 @@ subsystems = [subsys0(), subsys1()]
 
 # Build piecewise affine system from its subsystems
 sys_dyn = PwaSysDyn(subsystems, cont_state_space)
-ax = sys_dyn.plot()
-ax.figure.savefig('pwa_sys_dyn.pdf')
+if plotting:
+    ax = sys_dyn.plot()
+    ax.figure.savefig('pwa_sys_dyn.pdf')
 # @pwasystem_end@
 
 # Continuous proposition
@@ -92,19 +93,19 @@ cont_props['lot'] = box2poly([[2., 3.], [1., 2.]])
 # Compute the proposition preserving partition
 # of the continuous state space
 cont_partition = prop2part(cont_state_space, cont_props)
-ax = cont_partition.plot()
-cont_partition.plot_props(ax=ax)
-ax.figure.savefig('spec_ppp.pdf')
+if plotting:
+    ax = cont_partition.plot()
+    cont_partition.plot_props(ax=ax)
+    ax.figure.savefig('spec_ppp.pdf')
 
 disc_dynamics = discretize(
     cont_partition, sys_dyn, closed_loop=True,
     N=8, min_cell_volume=0.1, plotit=plotting, save_img=True,
-    cont_props=cont_props
-)
-ax = disc_dynamics.plot(show_ts=True)
-ax.figure.savefig('abs_pwa.pdf')
-
-disc_dynamics.ts.save('ts.pdf')
+    cont_props=cont_props)
+if plotting:
+    ax = disc_dynamics.plot(show_ts=True)
+    ax.figure.savefig('abs_pwa.pdf')
+    disc_dynamics.ts.save('ts.pdf')
 
 # Specifications
 

--- a/examples/pwa.py
+++ b/examples/pwa.py
@@ -132,7 +132,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
 
 # Synthesize
-ctrl = synth.synthesize('gr1c', specs,
+ctrl = synth.synthesize('omega', specs,
                         sys=disc_dynamics.ts, ignore_sys_init=True)
 if plotting:
     ax = plot_strategy(disc_dynamics, ctrl)

--- a/examples/pwa.py
+++ b/examples/pwa.py
@@ -14,7 +14,8 @@ from tulip import spec
 from tulip import synth
 
 
-plotting = True
+# set to `True` if `matplotlib.pyplot` is available
+plotting = False
 
 # Problem parameters
 input_bound = 0.4

--- a/examples/pwa.py
+++ b/examples/pwa.py
@@ -130,6 +130,8 @@ sys_prog |= {'X0reach'}
 # Create the specification
 specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
+specs.moore = True
+specs.qinit = '\E \A'
 
 # Synthesize
 ctrl = synth.synthesize('omega', specs,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ numpy==1.7
 scipy
 
 # easy extras
-omega==0.0.8
 gr1py>=0.1.0
 
 # extras (uncomment as needed)

--- a/run_tests.py
+++ b/run_tests.py
@@ -183,6 +183,7 @@ def main():
             'form_test',
             'gr1cint_test',
             'gr1_test',
+            'omega_interface_test',
             'spec_test',
             'synth_test',
             'transform_test',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def package_jtlv():
     else:
         print('The jtlv synthesis tool was not found. '
               'Try extern/get-jtlv.sh to get it.\n'
-              'It is an optional alternative to gr1c, '
+              'It is an optional alternative to `omega`, '
               'the default GR(1) solver of TuLiP.')
 
 

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ def run_setup():
         install_requires=[
             'networkx >= 1.6, <= 1.10',
             'numpy >= 1.7',
+            'omega >= 0.0.9, < 0.1.0',
             'ply >= 3.4',
             'polytope >= 0.1.2',
             'pydot >= 1.2.0',

--- a/tests/dumpsmach_test.py
+++ b/tests/dumpsmach_test.py
@@ -1,25 +1,37 @@
 #!/usr/bin/env python
 """Tests for the export mechanisms of tulip.dumpsmach."""
+import logging
+
 import networkx as nx
 from nose.tools import assert_raises
+
 from tulip import spec, synth, dumpsmach
+
+
+logging.getLogger('tulip').setLevel('ERROR')
+logging.getLogger('astutils').setLevel('ERROR')
+logging.getLogger('omega').setLevel('ERROR')
 
 
 class basic_test:
     def setUp(self):
         self.triv = spec.GRSpec(env_vars="x", sys_vars="y",
-                                env_init="x", env_prog="x",
+                                env_init="x & y", env_prog="x",
                                 sys_init="y", sys_prog="y && x")
-        self.triv_M = synth.synthesize("gr1c", self.triv)
+        self.triv_M = synth.synthesize('omega', self.triv)
 
-        self.dcounter = spec.GRSpec(sys_vars={"y": (0, 5)}, sys_init=["y=0"],
-                                    sys_prog=["y=0", "y=5"])
-        self.dcounter_M = synth.synthesize("gr1c", self.dcounter)
+        self.dcounter = spec.GRSpec(
+            sys_vars={"y": (0, 5)},
+            env_init=['y = 0'],
+            sys_prog=["y=0", "y=5"])
+        self.dcounter_M = synth.synthesize('omega', self.dcounter)
 
-        self.enumf = spec.GRSpec(sys_vars={'y': ['a', 'b']}, sys_init=['y="a"'],
-                                 sys_safety=['y = "a" -> X(y = "b")',
-                                             'y = "b" -> X(y = "a")'])
-        self.enumf_M = synth.synthesize('gr1c', self.enumf)
+        self.enumf = spec.GRSpec(
+            sys_vars={'y': ['a', 'b']},
+            env_init=['y="a"'],
+            sys_safety=['y = "a" -> X(y = "b")',
+                        'y = "b" -> X(y = "a")'])
+        self.enumf_M = synth.synthesize('omega', self.enumf)
 
     def tearDown(self):
         self.dcounter = None

--- a/tests/gr1_test.py
+++ b/tests/gr1_test.py
@@ -67,11 +67,18 @@ def test_stability():
     assert 'a' in s.sys_vars
     assert 'p' in s.sys_vars
 
+    s.moore = False
+    s.plus_one = False
+    s.qinit = '\A \E'
+
     # p && X[]!p
     s0 = spec.GRSpec(
         sys_vars={'p'}, sys_init={'p'},
         sys_safety={'p -> X !p',
-                    '!p -> X !p'}
+                    '!p -> X !p'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert not synth.is_realizable('gr1c', s | s0)
 
@@ -79,14 +86,20 @@ def test_stability():
     s1 = spec.GRSpec(
         sys_vars={'p'}, sys_init={'!p'},
         sys_safety={'!p -> X p',
-                    'p -> X p'}
+                    'p -> X p'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert synth.is_realizable('gr1c', s | s1)
 
     # []<>p && []<>!p
     s2 = spec.GRSpec(
         sys_vars={'p'},
-        sys_prog={'p', '!p'}
+        sys_prog={'p', '!p'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert not synth.is_realizable('gr1c', s | s2)
 
@@ -99,7 +112,10 @@ def test_stability():
         env_vars={'b'}, env_init={'b'},
         env_prog={'!b'},
         sys_vars={'p'}, sys_init={'!p'},
-        sys_safety={'(b && !p) -> X !p'})
+        sys_safety={'(b && !p) -> X !p'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E')
 
     assert synth.is_realizable('gr1c', s | s3)
 
@@ -119,33 +135,52 @@ def test_response():
     assert 'p' in s.sys_vars
     assert 'q' in s.sys_vars
 
+    s.moore = False
+    s.plus_one = False
+    s.qinit = '\A \E'
+
     # p && []!q
     s0 = spec.GRSpec(
-        sys_vars={'p', 'q'}, sys_init={'p'},
-        sys_safety={'!q'}
+        sys_vars={'p', 'q'},
+        sys_init={'p'},
+        sys_safety={'!q'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert not synth.is_realizable('gr1c', s | s0)
 
     # []!p && []!q
     s1 = spec.GRSpec(
-        sys_vars={'p', 'q'}, sys_safety={'!p && !q'}
+        sys_vars={'p', 'q'},
+        sys_safety={'!p && !q'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert synth.is_realizable('gr1c', s | s1)
 
     # p && q
     s2 = spec.GRSpec(
-        sys_vars={'p', 'q'}, sys_init={'p && q'},
+        sys_vars={'p', 'q'},
+        sys_init={'p && q'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert synth.is_realizable('gr1c', s | s2)
 
     # alternating p, alternating q
     s3 = spec.GRSpec(
-        sys_vars={'p', 'q'}, sys_safety={
+        sys_vars={'p', 'q'},
+        sys_safety={
             'p -> X !p',
             '!p -> X p',
             'p -> X q',
-            'q -> X ! q'
-        }
+            'q -> X ! q'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert synth.is_realizable('gr1c', s | s3)
     # print((s | s2).pretty() )
@@ -159,16 +194,28 @@ def test_eventually():
     assert 'c' in s.sys_vars
     assert 'p' in s.sys_vars
 
+    s.moore = False
+    s.plus_one = False
+    s.qinit = '\A \E'
+
     # []!p
     s0 = spec.GRSpec(
-        sys_vars={'p'}, sys_safety={'!p'}
+        sys_vars={'p'},
+        sys_safety={'!p'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert not synth.is_realizable('gr1c', s | s0)
 
     # !p && []<>p && []<>!p
     s1 = spec.GRSpec(
-        sys_vars={'p'}, sys_init={'!p'},
-        sys_prog={'!p', 'p'}
+        sys_vars={'p'},
+        sys_init={'!p'},
+        sys_prog={'!p', 'p'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert synth.is_realizable('gr1c', s | s1)
 
@@ -187,24 +234,40 @@ def test_until():
     assert 'p' in s.sys_vars
     assert 'q' in s.sys_vars
 
+    s.moore = False
+    s.plus_one = False
+    s.qinit = '\A \E'
+
     # []!q
     s0 = spec.GRSpec(
-        sys_vars={'q'}, sys_safety={'!q'}
+        sys_vars={'q'},
+        sys_safety={'!q'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert not synth.is_realizable('gr1c', s | s0)
 
     # !q && <>q
     s1 = spec.GRSpec(
-        sys_vars={'q'}, sys_init={'!q'},
-        sys_prog={'q'}
+        sys_vars={'q'},
+        sys_init={'!q'},
+        sys_prog={'q'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert synth.is_realizable('gr1c', s | s1)
 
     # !q && []!p && <>q
     s1 = spec.GRSpec(
-        sys_vars={'q'}, sys_init={'!q'},
+        sys_vars={'q'},
+        sys_init={'!q'},
         sys_safety={'!p'},
-        sys_prog={'q'}
+        sys_prog={'q'},
+        moore=False,
+        plus_one=False,
+        qinit='\A \E'
     )
     assert not synth.is_realizable('gr1c', s | s1)
 

--- a/tests/gr1_test.py
+++ b/tests/gr1_test.py
@@ -3,6 +3,8 @@
 import logging
 logging.basicConfig(level=logging.DEBUG)
 logging.getLogger('tulip.ltl_parser_log').setLevel(logging.WARNING)
+logging.getLogger('tulip.spec.form').setLevel(logging.WARNING)
+logging.getLogger('omega').setLevel(logging.WARNING)
 from nose.tools import assert_raises
 from tulip import spec, synth
 from tulip.spec import parser, transformation
@@ -80,7 +82,7 @@ def test_stability():
         plus_one=False,
         qinit='\A \E'
     )
-    assert not synth.is_realizable('gr1c', s | s0)
+    assert not synth.is_realizable('omega', s | s0)
 
     # !p && X[]p
     s1 = spec.GRSpec(
@@ -91,7 +93,7 @@ def test_stability():
         plus_one=False,
         qinit='\A \E'
     )
-    assert synth.is_realizable('gr1c', s | s1)
+    assert synth.is_realizable('omega', s | s1)
 
     # []<>p && []<>!p
     s2 = spec.GRSpec(
@@ -101,7 +103,7 @@ def test_stability():
         plus_one=False,
         qinit='\A \E'
     )
-    assert not synth.is_realizable('gr1c', s | s2)
+    assert not synth.is_realizable('omega', s | s2)
 
     # env b can prevent !p, but has tp <> become !b,
     # releasing sys to set p
@@ -117,14 +119,14 @@ def test_stability():
         plus_one=False,
         qinit='\A \E')
 
-    assert synth.is_realizable('gr1c', s | s3)
+    assert synth.is_realizable('omega', s | s3)
 
     s3.env_prog = []
-    assert not synth.is_realizable('gr1c', s | s3)
+    assert not synth.is_realizable('omega', s | s3)
 
     # s4 = s | s3
     # print(s4.pretty() )
-    # mealy = synth.synthesize('gr1c', s4)
+    # mealy = synth.synthesize('omega', s4)
     # mealy.save()
 
 
@@ -148,7 +150,7 @@ def test_response():
         plus_one=False,
         qinit='\A \E'
     )
-    assert not synth.is_realizable('gr1c', s | s0)
+    assert not synth.is_realizable('omega', s | s0)
 
     # []!p && []!q
     s1 = spec.GRSpec(
@@ -158,7 +160,7 @@ def test_response():
         plus_one=False,
         qinit='\A \E'
     )
-    assert synth.is_realizable('gr1c', s | s1)
+    assert synth.is_realizable('omega', s | s1)
 
     # p && q
     s2 = spec.GRSpec(
@@ -168,7 +170,7 @@ def test_response():
         plus_one=False,
         qinit='\A \E'
     )
-    assert synth.is_realizable('gr1c', s | s2)
+    assert synth.is_realizable('omega', s | s2)
 
     # alternating p, alternating q
     s3 = spec.GRSpec(
@@ -182,7 +184,7 @@ def test_response():
         plus_one=False,
         qinit='\A \E'
     )
-    assert synth.is_realizable('gr1c', s | s3)
+    assert synth.is_realizable('omega', s | s3)
     # print((s | s2).pretty() )
 
 
@@ -206,7 +208,7 @@ def test_eventually():
         plus_one=False,
         qinit='\A \E'
     )
-    assert not synth.is_realizable('gr1c', s | s0)
+    assert not synth.is_realizable('omega', s | s0)
 
     # !p && []<>p && []<>!p
     s1 = spec.GRSpec(
@@ -217,11 +219,11 @@ def test_eventually():
         plus_one=False,
         qinit='\A \E'
     )
-    assert synth.is_realizable('gr1c', s | s1)
+    assert synth.is_realizable('omega', s | s1)
 
     # s2 = s | s1
     # print(s4.pretty() )
-    # mealy = synth.synthesize('gr1c', s4)
+    # mealy = synth.synthesize('omega', s4)
     # mealy.save()
 
 
@@ -246,7 +248,7 @@ def test_until():
         plus_one=False,
         qinit='\A \E'
     )
-    assert not synth.is_realizable('gr1c', s | s0)
+    assert not synth.is_realizable('omega', s | s0)
 
     # !q && <>q
     s1 = spec.GRSpec(
@@ -257,7 +259,7 @@ def test_until():
         plus_one=False,
         qinit='\A \E'
     )
-    assert synth.is_realizable('gr1c', s | s1)
+    assert synth.is_realizable('omega', s | s1)
 
     # !q && []!p && <>q
     s1 = spec.GRSpec(
@@ -269,7 +271,7 @@ def test_until():
         plus_one=False,
         qinit='\A \E'
     )
-    assert not synth.is_realizable('gr1c', s | s1)
+    assert not synth.is_realizable('omega', s | s1)
 
 
 if __name__ == '__main__':

--- a/tests/gr1cint_test.py
+++ b/tests/gr1cint_test.py
@@ -86,12 +86,24 @@ REFERENCE_AUTJSON_smallbool = """
 class basic_test:
     def setUp(self):
         self.f_un = GRSpec(
-            env_vars="x", sys_vars="y",
-            env_init="x", env_prog="x",
-            sys_init="y", sys_safety=["y -> X(!y)", "!y -> X(y)"],
-            sys_prog="y && x")
-        self.dcounter = GRSpec(sys_vars={"y": (0, 5)}, sys_init=["y=0"],
-                               sys_prog=["y=0", "y=5"])
+            env_vars="x",
+            sys_vars="y",
+            env_init="x",
+            env_prog="x",
+            sys_init="y",
+            sys_safety=["y -> X(!y)", "!y -> X(y)"],
+            sys_prog="y && x",
+            moore=False,
+            plus_one=False,
+            qinit='\A \E')
+        self.dcounter = GRSpec(
+            env_init=['True'],
+            sys_vars={"y": (0, 5)},
+            sys_init=["y=0"],
+            sys_prog=["y=0", "y=5"],
+            moore=False,
+            plus_one=False,
+            qinit='\A \E')
 
     def tearDown(self):
         self.f_un = None

--- a/tests/gr1cint_test.py
+++ b/tests/gr1cint_test.py
@@ -118,30 +118,26 @@ class basic_test:
         assert gr1c.check_syntax(translate(self.dcounter, 'gr1c'))
 
     def test_check_realizable(self):
-        assert not gr1c.check_realizable(self.f_un,
-                                         init_option="ALL_ENV_EXIST_SYS_INIT")
+        assert not gr1c.check_realizable(self.f_un)
         self.f_un.sys_safety = []
-        assert gr1c.check_realizable(self.f_un,
-                                     init_option="ALL_ENV_EXIST_SYS_INIT")
-        assert gr1c.check_realizable(self.f_un,
-                                     init_option="ALL_INIT")
-
-        assert gr1c.check_realizable(self.dcounter,
-                                     init_option="ALL_ENV_EXIST_SYS_INIT")
-        self.dcounter.sys_init = []
-        assert gr1c.check_realizable(self.dcounter,
-                                     init_option="ALL_INIT")
+        assert gr1c.check_realizable(self.f_un)
+        self.f_un.qinit = '\A \A'
+        self.f_un.env_init = ['x', 'y = 0', 'y = 5']
+        self.f_un.sys_init = list()
+        assert gr1c.check_realizable(self.f_un)
+        assert gr1c.check_realizable(self.dcounter)
+        self.dcounter.qinit = '\A \A'
+        self.dcounter.sys_init = list()
+        assert gr1c.check_realizable(self.dcounter)
 
     def test_synthesize(self):
-        self.f_un.sys_safety = []  # Make it realizable
-        g = gr1c.synthesize(self.f_un,
-                            init_option="ALL_ENV_EXIST_SYS_INIT")
+        self.f_un.sys_safety = list()  # Make it realizable
+        g = gr1c.synthesize(self.f_un)
         assert g is not None
         assert len(g.env_vars) == 1 and 'x' in g.env_vars
         assert len(g.sys_vars) == 1 and 'y' in g.sys_vars
 
-        g = gr1c.synthesize(self.dcounter,
-                            init_option="ALL_ENV_EXIST_SYS_INIT")
+        g = gr1c.synthesize(self.dcounter)
         assert g is not None
         assert len(g.env_vars) == 0
         assert len(g.sys_vars) == 1 and 'y' in g.sys_vars
@@ -149,14 +145,14 @@ class basic_test:
 
         # In the notation of gr1c SYSINIT: True;, so the strategy must
         # account for every initial state, i.e., for y=0, y=1, y=2, ...
-        self.dcounter.sys_init = []
-        g = gr1c.synthesize(self.dcounter,
-                            init_option="ALL_INIT")
+        self.dcounter.qinit = '\A \A'
+        self.dcounter.sys_init = list()
+        g = gr1c.synthesize(self.dcounter)
         assert g is not None
         print g
         assert len(g.env_vars) == 0
         assert len(g.sys_vars) == 1 and 'y' in g.sys_vars
-        assert len(g) == 6
+        assert len(g) == 6, len(g)
 
 
 class GR1CSession_test:
@@ -253,8 +249,8 @@ def test_load_aut_json():
 
 @raises(ValueError)
 def synth_init_illegal_check(init_option):
-    spc = GRSpec()
-    gr1c.synthesize(spc, init_option=init_option)
+    spc = GRSpec(moore=False, plus_one=False, qinit=init_option)
+    gr1c.synthesize(spc)
 
 
 def synth_init_illegal_test():
@@ -264,8 +260,8 @@ def synth_init_illegal_test():
 
 @raises(ValueError)
 def realiz_init_illegal_check(init_option):
-    spc = GRSpec()
-    gr1c.check_realizable(spc, init_option=init_option)
+    spc = GRSpec(moore=False, plus_one=False, qinit=init_option)
+    gr1c.check_realizable(spc)
 
 
 def realiz_init_illegal_test():

--- a/tests/gr1pyint_test.py
+++ b/tests/gr1pyint_test.py
@@ -5,13 +5,13 @@ Tests for the interface with gr1py.
 import logging
 logging.basicConfig(level=logging.DEBUG)
 logging.getLogger('tulip.spec.lexyacc').setLevel(logging.WARNING)
-from nose.tools import raises
+from nose.tools import assert_raises
 import os
 from tulip.spec import GRSpec, translate
 from tulip.interfaces import gr1py
 
 
-class basic_test:
+class basic_test(object):
     def setUp(self):
         self.f_un = GRSpec(
             env_vars="x",
@@ -37,30 +37,30 @@ class basic_test:
         self.dcounter = None
 
     def test_check_realizable(self):
-        assert not gr1py.check_realizable(self.f_un,
-                                          init_option="ALL_ENV_EXIST_SYS_INIT")
+        # f_un
+        assert not gr1py.check_realizable(self.f_un)
         self.f_un.sys_safety = []
-        assert gr1py.check_realizable(self.f_un,
-                                      init_option="ALL_ENV_EXIST_SYS_INIT")
-        assert gr1py.check_realizable(self.f_un,
-                                      init_option="ALL_INIT")
-
-        assert gr1py.check_realizable(self.dcounter,
-                                      init_option="ALL_ENV_EXIST_SYS_INIT")
-        self.dcounter.sys_init = []
-        assert gr1py.check_realizable(self.dcounter,
-                                      init_option="ALL_INIT")
+        assert gr1py.check_realizable(self.f_un)
+        self.f_un.qinit = '\A \A'
+        self.f_un.env_init = ['x & y']
+        self.f_un.sys_init = list()
+        with assert_raises(AssertionError):
+            assert gr1py.check_realizable(self.f_un)
+        # counter
+        assert gr1py.check_realizable(self.dcounter)
+        self.dcounter.qinit = '\A \A'
+        self.dcounter.sys_init = list()
+        with assert_raises(AssertionError):
+            assert gr1py.check_realizable(self.dcounter)
 
     def test_synthesize(self):
         self.f_un.sys_safety = []  # Make it realizable
-        g = gr1py.synthesize(self.f_un,
-                             init_option="ALL_ENV_EXIST_SYS_INIT")
+        g = gr1py.synthesize(self.f_un)
         assert g is not None
         assert len(g.env_vars) == 1 and 'x' in g.env_vars
         assert len(g.sys_vars) == 1 and 'y' in g.sys_vars
 
-        g = gr1py.synthesize(self.dcounter,
-                             init_option="ALL_ENV_EXIST_SYS_INIT")
+        g = gr1py.synthesize(self.dcounter)
         assert g is not None
         assert len(g.env_vars) == 0
         assert len(g.sys_vars) == 1 and 'y' in g.sys_vars

--- a/tests/gr1pyint_test.py
+++ b/tests/gr1pyint_test.py
@@ -14,12 +14,23 @@ from tulip.interfaces import gr1py
 class basic_test:
     def setUp(self):
         self.f_un = GRSpec(
-            env_vars="x", sys_vars="y",
-            env_init="x", env_prog="x",
-            sys_init="y", sys_safety=["y -> X(!y)", "!y -> X(y)"],
-            sys_prog="y && x")
-        self.dcounter = GRSpec(sys_vars={"y": (0, 5)}, sys_init=["y=0"],
-                               sys_prog=["y=0", "y=5"])
+            env_vars="x",
+            sys_vars="y",
+            env_init="x",
+            env_prog="x",
+            sys_init="y",
+            sys_safety=["y -> X(!y)", "!y -> X(y)"],
+            sys_prog="y && x",
+            moore=False,
+            plus_one=False,
+            qinit='\A \E')
+        self.dcounter = GRSpec(
+            sys_vars={"y": (0, 5)},
+            sys_init=["y=0"],
+            sys_prog=["y=0", "y=5"],
+            moore=False,
+            plus_one=False,
+            qinit='\A \E')
 
     def tearDown(self):
         self.f_un = None

--- a/tests/gridworld_test.py
+++ b/tests/gridworld_test.py
@@ -149,14 +149,14 @@ class GridWorld_test(object):
         spec.moore = False
         spec.plus_one = False
         spec.qinit = r'\A \E'
-        assert is_realizable('gr1c', spec)
+        assert is_realizable('omega', spec)
 
     def test_spec_realizable(self):
         spec = self.X.spec()
         spec.moore = False
         spec.plus_one = False
         spec.qinit = r'\A \E'
-        assert is_realizable('gr1c', spec)
+        assert is_realizable('omega', spec)
 
     def check_is_empty(self, coord, expected):
         assert self.X.is_empty(coord) == expected
@@ -339,4 +339,4 @@ def add_trolls_test():
     spc.moore = False
     spc.plus_one = False
     spc.qinit = r'\A \E'
-    assert is_realizable('gr1c', spc)
+    assert is_realizable('omega', spc)

--- a/tests/gridworld_test.py
+++ b/tests/gridworld_test.py
@@ -145,10 +145,18 @@ class GridWorld_test(object):
         assert self.X == gw.GridWorld(self.X.dumps())
 
     def test_spec_realizable_bool(self):
-        assert is_realizable('gr1c', self.X.spec(nonbool=False))
+        spec = self.X.spec(nonbool=False)
+        spec.moore = False
+        spec.plus_one = False
+        spec.qinit = r'\A \E'
+        assert is_realizable('gr1c', spec)
 
     def test_spec_realizable(self):
-        assert is_realizable('gr1c', self.X.spec())
+        spec = self.X.spec()
+        spec.moore = False
+        spec.plus_one = False
+        spec.qinit = r'\A \E'
+        assert is_realizable('gr1c', spec)
 
     def check_is_empty(self, coord, expected):
         assert self.X.is_empty(coord) == expected
@@ -328,4 +336,7 @@ def add_trolls_test():
     G.init_list = [(0, 0)]
     G.goal_list = [(0, 4)]
     spc = gw.add_trolls(G, [((2, 2), 1)], get_moves_lists=False)
+    spc.moore = False
+    spc.plus_one = False
+    spc.qinit = r'\A \E'
     assert is_realizable('gr1c', spc)

--- a/tests/jtlvint_test.py
+++ b/tests/jtlvint_test.py
@@ -17,13 +17,16 @@ class basic_test(object):
         self.f_un = GRSpec(env_vars="x", sys_vars="y",
                            env_init="x", env_prog="x",
                            sys_init="y", sys_safety=["y -> X(!y)", "!y -> X(y)"],
-                           sys_prog="y && x")
+                           sys_prog="y && x",
+                           moore=False, plus_one=False, qinit='\A \E')
         self.f = GRSpec(env_vars="x", sys_vars="y",
                         env_init="x", env_prog="x",
                         sys_init="y",
-                        sys_prog=["y & x", "!y"])
+                        sys_prog=["y & x", "!y"],
+                        moore=False, plus_one=False, )
         self.dcounter = GRSpec(sys_vars={"y": (0,5)}, sys_init=["y=0"],
-                               sys_prog=["y=0", "y=5"])
+                               sys_prog=["y=0", "y=5"],
+                               moore=False, plus_one=False, qinit='\A \E')
 
     def tearDown(self):
         self.f_un = None
@@ -69,13 +72,13 @@ class basic_test(object):
 def hash_question_mark_test():
     specs = GRSpec(env_vars={'w': ['low', 'medium', 'high']},
                    sys_vars={'a': (0, 2)},
-
-                    env_init=['w="low"'],
-                    env_safety=['(a=1) -> ((w="low") || (w="medium"))'],
-                    env_prog=['(w="high")'],
-
-                    sys_init=['a=2'],
-                    sys_safety=['a=2'],
-                    sys_prog=['a=2'])
+                   # env
+                   env_init=['w="low"'],
+                   env_safety=['(a=1) -> ((w="low") || (w="medium"))'],
+                   env_prog=['(w="high")'],
+                   sys_init=['a=2'],
+                   sys_safety=['a=2'],
+                   sys_prog=['a=2'],
+                   moore=False, plus_one=False, qinit='\A \E')
     with nt.assert_raises(ValueError):
         jtlv.synthesize(specs)

--- a/tests/omega_interface_test.py
+++ b/tests/omega_interface_test.py
@@ -1,10 +1,17 @@
 """Tests for interface to `omega.games.gr1`."""
 import logging
+
+import networkx as nx
+
 from tulip.spec import form
 from tulip.interfaces import omega as omega_int
 from tulip import synth
 
 
+from nose import tools as nt
+
+
+logging.getLogger('tulip').setLevel('ERROR')
 logging.getLogger('astutils').setLevel('ERROR')
 logging.getLogger('omega').setLevel('ERROR')
 log = logging.getLogger('omega.games')
@@ -31,6 +38,7 @@ def test_grspec_to_automaton():
 def test_synthesis_bool():
     sp = grspec_0()
     h = omega_int.synthesize_enumerated_streett(sp)
+    assert h is not None, 'no winning states'
     g = synth.strategy2mealy(h, sp)
     # fname = 'mealy.pdf'
     # g.save(fname)
@@ -69,7 +77,7 @@ def test_synthesis_fol():
 
 
 def test_synthesis_strings():
-    sp = grspec_2()
+    sp = grspec_4()
     h = omega_int.synthesize_enumerated_streett(sp)
     g = synth.strategy2mealy(h, sp)
     assert g is not None
@@ -91,6 +99,29 @@ def test_synthesis_strings():
     assert r == dict(y='b'), r
     u, r = g.reaction(u, dict(x=0))
     assert r == dict(y='a'), r
+
+
+def test_synthesis_moore():
+    sp = grspec_2()
+    h = omega_int.synthesize_enumerated_streett(sp)
+    g = synth.strategy2mealy(h, sp)
+    # g.save('moore.pdf')
+    assert g is not None
+    n = len(g)
+    assert n == 26, n
+
+
+def test_synthesis_mealy_all_init():
+    sp = grspec_3()
+    with nt.assert_raises(AssertionError):
+        omega_int.synthesize_enumerated_streett(sp)
+    sp.env_init = ['y = x']
+    h = omega_int.synthesize_enumerated_streett(sp)
+    g = synth.strategy2mealy(h, sp)
+    # g.save('moore.pdf')
+    assert g is not None
+    n = len(g)
+    assert n == 6, n
 
 
 def test_synthesis_unrealizable():
@@ -136,6 +167,7 @@ def test_is_circular_cudd():
 
 def grspec_0():
     sp = form.GRSpec()
+    sp.moore = False
     sp.env_vars = dict(x='boolean')
     sp.sys_vars = dict(y='boolean')
     sp.sys_safety = ["x' -> y'"]
@@ -146,14 +178,37 @@ def grspec_0():
 
 def grspec_1():
     sp = form.GRSpec()
+    sp.moore = False
     sp.env_vars = dict(x=(0, 4))
     sp.sys_vars = dict(y=(0, 4))
-    sp.sys_safety = ["x' = y'"]
+    sp.env_init = ['(0 <= y) & (y <= 4)']
+    sp.sys_safety = ["y' = x'"]
     return sp
 
 
 def grspec_2():
     sp = form.GRSpec()
+    sp.moore = True
+    sp.env_vars = dict(x=(0, 4))
+    sp.sys_vars = dict(y=(0, 4))
+    sp.env_init = ['(0 <= y) & (y <= 4)']
+    sp.sys_safety = ["y' = x"]
+    return sp
+
+def grspec_3():
+    sp = form.GRSpec()
+    sp.moore = False
+    sp.env_vars = dict(x=(0, 4))
+    sp.sys_vars = dict(y=(0, 4))
+    sp.env_init = ['(0 <= y) & (y <= 4)']
+    sp.sys_safety = ["y = x"]
+    return sp
+
+
+def grspec_4():
+    sp = form.GRSpec()
+    sp.moore = False
+    sp.env_init = ['(x = 0) & (y = "a")']
     sp.env_vars = dict(x=(0, 2))
     sp.sys_vars = dict(y=['a', 'b'])
     sp.sys_safety = [
@@ -163,4 +218,4 @@ def grspec_2():
 
 
 if __name__ == '__main__':
-    test_synthesis_cudd()
+    test_synthesis_bool()

--- a/tests/omega_interface_test.py
+++ b/tests/omega_interface_test.py
@@ -62,6 +62,7 @@ def test_synthesis_bool():
 def test_synthesis_fol():
     sp = grspec_1()
     h = omega_int.synthesize_enumerated_streett(sp)
+    assert h is not None
     g = synth.strategy2mealy(h, sp)
     assert g is not None
     assert len(g.inputs) == 1, g.inputs
@@ -152,6 +153,7 @@ def test_is_circular_false():
 def test_synthesis_cudd():
     sp = grspec_1()
     h = omega_int.synthesize_enumerated_streett(sp, use_cudd=True)
+    assert h is not None
     n = len(h)
     assert n == 25, n
 

--- a/tests/omega_interface_test.py
+++ b/tests/omega_interface_test.py
@@ -113,8 +113,8 @@ def test_synthesis_moore():
 
 def test_synthesis_mealy_all_init():
     sp = grspec_3()
-    with nt.assert_raises(AssertionError):
-        omega_int.synthesize_enumerated_streett(sp)
+    h = omega_int.synthesize_enumerated_streett(sp)
+    assert h is None, 'should be unrealizable'
     sp.env_init = ['y = x']
     h = omega_int.synthesize_enumerated_streett(sp)
     g = synth.strategy2mealy(h, sp)
@@ -179,6 +179,7 @@ def grspec_0():
 def grspec_1():
     sp = form.GRSpec()
     sp.moore = False
+    sp.plus_one = False
     sp.env_vars = dict(x=(0, 4))
     sp.sys_vars = dict(y=(0, 4))
     sp.env_init = ['(0 <= y) & (y <= 4)']

--- a/tests/omega_interface_test.py
+++ b/tests/omega_interface_test.py
@@ -6,7 +6,10 @@ from tulip import synth
 
 
 logging.getLogger('astutils').setLevel('ERROR')
-logging.getLogger('omega.logic').setLevel('ERROR')
+logging.getLogger('omega').setLevel('ERROR')
+log = logging.getLogger('omega.games')
+log.setLevel('WARNING')
+log.addHandler(logging.StreamHandler())
 
 
 def test_grspec_to_automaton():

--- a/tests/synth_test.py
+++ b/tests/synth_test.py
@@ -373,7 +373,7 @@ def multiple_env_actions_test():
     next combination of actions by env players.
     """
     # 1 <---> 2
-    #    ---> 3
+    # 1  ---> 3
 
     env_actions = [
         {
@@ -391,9 +391,9 @@ def multiple_env_actions_test():
     sys.states.initial.add_from({'s1'})
 
     sys.add_edge('s1', 's2', env_alice='left', env_bob='bright')
+    sys.add_edge('s2', 's1', env_alice='left', env_bob='bright')
     # at state 3 sys loses
     sys.add_edge('s1', 's3', env_alice='right', env_bob='bleft')
-    sys.add_edge('s2', 's1', env_alice='left', env_bob='bright')
 
     logging.debug(sys)
 
@@ -623,8 +623,12 @@ class synthesize_test:
         self.f_triv = None
 
     def test_gr1c_basic(self):
-        assert isinstance(synth.synthesize("gr1c", self.f_triv),
-                          transys.MealyMachine)
+        g = synth.synthesize("gr1c", self.f_triv)
+        assert isinstance(g, transys.MealyMachine)
 
     def test_unrealizable(self):
         assert synth.synthesize("gr1c", self.trivial_unreachable) is None
+
+
+if __name__ == '__main__':
+    multiple_env_actions_test()

--- a/tests/synth_test.py
+++ b/tests/synth_test.py
@@ -401,14 +401,21 @@ def multiple_env_actions_test():
                  '(env_bob = "bright") )')}
     sys_prog = {'loc = "s1"', 'loc = "s2"'}
 
-    specs = spec.GRSpec(env_safety=env_safe, sys_prog=sys_prog)
-
+    specs = spec.GRSpec(
+        env_safety=env_safe,
+        sys_prog=sys_prog,
+        moore=False,
+        plus_one=False,
+        qinit='\A \E')
     r = synth.is_realizable('gr1c', specs, sys=sys)
     assert r
 
     # slightly relax assumption
-    specs = spec.GRSpec(sys_prog=sys_prog)
-
+    specs = spec.GRSpec(
+        sys_prog=sys_prog,
+        moore=False,
+        plus_one=False,
+        qinit='\A \E')
     r = synth.is_realizable('gr1c', specs, sys=sys)
     assert not r
 
@@ -616,8 +623,15 @@ def test_determinize_machine_init():
 
 class synthesize_test:
     def setUp(self):
-        self.f_triv = spec.GRSpec(sys_vars="y")
-        self.trivial_unreachable = spec.GRSpec(sys_vars="y", sys_prog="False")
+        self.f_triv = spec.GRSpec(
+            sys_vars="y",
+            moore=False,
+            plus_one=False)
+        self.trivial_unreachable = spec.GRSpec(
+            sys_vars="y",
+            sys_prog="False",
+            moore=False,
+            plus_one=False)
 
     def tearDown(self):
         self.f_triv = None

--- a/tests/synth_test.py
+++ b/tests/synth_test.py
@@ -410,7 +410,8 @@ def multiple_env_actions_test():
         qinit='\A \E')
     r = synth.is_realizable('gr1c', specs, sys=sys)
     assert r
-
+    r = synth.is_realizable('omega', specs, sys=sys)
+    assert r
     # slightly relax assumption
     specs = spec.GRSpec(
         sys_prog=sys_prog,
@@ -418,6 +419,8 @@ def multiple_env_actions_test():
         plus_one=False,
         qinit='\A \E')
     r = synth.is_realizable('gr1c', specs, sys=sys)
+    assert not r
+    r = synth.is_realizable('omega', specs, sys=sys)
     assert not r
 
 

--- a/tests/synth_test.py
+++ b/tests/synth_test.py
@@ -4,6 +4,7 @@ Tests for the tulip.synth module.
 import logging
 logging.getLogger('tulip').setLevel(logging.ERROR)
 logging.getLogger('tulip.interfaces.gr1c').setLevel(logging.DEBUG)
+logging.getLogger('omega').setLevel(logging.WARNING)
 from nose.tools import assert_raises
 import numpy as np
 from scipy import sparse as sp
@@ -362,7 +363,7 @@ def test_only_mode_control():
     specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                         env_safe, sys_safe, env_prog, sys_prog)
 
-    r = synth.is_realizable('gr1c', specs, env=env_sws, ignore_env_init=True)
+    r = synth.is_realizable('omega', specs, env=env_sws, ignore_env_init=True)
     assert not r
 
 

--- a/tulip/interfaces/gr1c.py
+++ b/tulip/interfaces/gr1c.py
@@ -402,7 +402,7 @@ def check_syntax(spec_str):
         logger.info(p.stdout.read() )
         return False
 
-def check_realizable(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
+def check_realizable(spec):
     """Decide realizability of specification.
 
     Consult the documentation of L{synthesize} about parameters.
@@ -430,42 +430,15 @@ def check_realizable(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
         logger.info(p.stdout.read() )
         return False
 
-def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
+def synthesize(spec):
     """Synthesize strategy realizing the given specification.
 
     @type spec: L{GRSpec}
-    @param spec: specification, which is incomplete without an
-        interpretation of initial conditions (init_option).
+    @param spec: specification.
 
-    @type init_option: str
-    @param init_option: string declaration of the initial condition
-        interpretation to use.  This parameter corresponds to that of
-        the -n command-line flag of gr1c.  It is one of:
-
-            - "ALL_ENV_EXIST_SYS_INIT" (default) - For each initial
-              valuation of environment variables that satisfies
-              spec.env_init, the strategy must provide some valuation
-              of system variables that satisfies spec.sys_init.  Only
-              environment variables (spec.env_vars) may appear in
-              spec.env_init, and only system variables (spec.sys_vars)
-              may appear in spec.sys_init.
-
-            - "ALL_INIT" - Any state that satisfies the conjunction of
-              spec.env_init an spec.sys_init can occur initially.
-
-            - "ONE_SIDE_INIT" - At most one of spec.env_init and
-              spec.sys_init is nonempty, and the nonempty one can
-              include both environment and system variables
-              (spec.env_vars and spec.sys_vars, respectively).  Both
-              being empty is equivalent to spec.env_init=["True"].  If
-              spec.env_init is nonempty, then any state satisfying it
-              is possible initially.  If spec.sys_init is nonempty,
-              then the strategy need only choose one initial state
-              satisfying it.
-
-        Consult the U{documentation of gr1c
-        <https://tulip-control.github.io/gr1c/md_spc_format.html#initconditions>}
-        for detailed descriptions.
+    Consult the U{documentation of gr1c
+    <https://tulip-control.github.io/gr1c/md_spc_format.html#initconditions>}
+    for a detailed description.
 
     @return: strategy as C{networkx.DiGraph},
         or None if unrealizable or error occurs.

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -38,6 +38,7 @@ from __future__ import absolute_import
 import logging
 from tulip.spec import translate
 from tulip.interfaces.gr1c import load_aut_json
+from tulip.interfaces.gr1c import select_options
 try:
     import gr1py
     import gr1py.cli
@@ -56,6 +57,7 @@ def check_realizable(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
 
     @return: True if realizable, False if not, or an error occurs.
     """
+    init_option = select_options(spec)
     tsys, exprtab = _spec_to_gr1py(spec)
     return gr1py.solve.check_realizable(tsys, exprtab)
 
@@ -64,6 +66,7 @@ def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
 
     cf. L{tulip.interfaces.gr1c.synthesize}
     """
+    init_option = select_options(spec)
     tsys, exprtab = _spec_to_gr1py(spec)
     strategy = gr1py.solve.synthesize(tsys, exprtab)
     if strategy is None:

--- a/tulip/interfaces/gr1py.py
+++ b/tulip/interfaces/gr1py.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 _hl = 60 * '-'
 
 
-def check_realizable(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
+def check_realizable(spec):
     """Decide realizability of specification.
 
     Consult the documentation of L{synthesize} about parameters.
@@ -59,16 +59,18 @@ def check_realizable(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
     """
     init_option = select_options(spec)
     tsys, exprtab = _spec_to_gr1py(spec)
-    return gr1py.solve.check_realizable(tsys, exprtab)
+    return gr1py.solve.check_realizable(
+        tsys, exprtab, init_flags=init_option)
 
-def synthesize(spec, init_option="ALL_ENV_EXIST_SYS_INIT"):
+def synthesize(spec):
     """Synthesize strategy realizing the given specification.
 
     cf. L{tulip.interfaces.gr1c.synthesize}
     """
     init_option = select_options(spec)
     tsys, exprtab = _spec_to_gr1py(spec)
-    strategy = gr1py.solve.synthesize(tsys, exprtab)
+    strategy = gr1py.solve.synthesize(
+        tsys, exprtab, init_flags=init_option)
     if strategy is None:
         return None
     s = gr1py.output.dump_json(tsys.symtab, strategy)

--- a/tulip/interfaces/jtlv.py
+++ b/tulip/interfaces/jtlv.py
@@ -57,6 +57,8 @@ def check_realizable(spec, heap_size='-Xmx128m', priority_kind=-1,
 
     @return: True if realizable, False if not, or an error occurs.
     """
+    assert not spec.moore
+    assert not spec.plus_one
     fSMV, fLTL, fAUT = create_files(spec)
     realizable = solve_game(spec, fSMV, fLTL, fAUT, heap_size,
                             priority_kind, init_option)
@@ -162,6 +164,8 @@ def synthesize(
     @return: Return strategy as instance of C{networkx.DiGraph}, or a
         list of counter-examples as returned by L{get_counterexamples}.
     """
+    assert not spec.moore
+    assert not spec.plus_one
     fSMV, fLTL, fAUT = create_files(spec)
 
     realizable = solve_game(spec, fSMV, fLTL, fAUT, heap_size,

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -12,8 +12,8 @@ U{https://pypi.python.org/pypi/omega}
 """
 from __future__ import absolute_import
 import logging
-import networkx as nx
 import time
+
 try:
     import dd.bdd as _bdd
 except ImportError:
@@ -30,6 +30,7 @@ try:
     from omega.games import enumeration as enum
 except ImportError:
     omega = None
+import networkx as nx
 
 
 log = logging.getLogger(__name__)

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -178,4 +178,7 @@ def _grspec_to_automaton(g):
         '!({s})'.format(s=s)
         for s in map(f, g.env_prog)]
     a.win['[]<>'] = map(f, g.sys_prog)
+    a.moore = g.moore
+    a.plus_one = g.plus_one
+    a.qinit = g.qinit
     return a

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -35,6 +35,22 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
+def is_realizable(spec, use_cudd=False):
+    """Return `True` if, and only if, realizable.
+
+    See `synthesize_enumerated_streett` for more details.
+    """
+    aut = _grspec_to_automaton(spec)
+    sym.fill_blanks(aut)
+    bdd = _init_bdd(use_cudd)
+    aut.bdd = bdd
+    a = aut.build()
+    t0 = time.time()
+    z, _, _ = gr1.solve_streett_game(a)
+    t1 = time.time()
+    return gr1.is_realizable(z, a)
+
+
 def synthesize_enumerated_streett(spec, use_cudd=False):
     """Return transducer enumerated as a graph.
 

--- a/tulip/interfaces/slugs.py
+++ b/tulip/interfaces/slugs.py
@@ -57,6 +57,8 @@ def check_realizable(spec):
     @return: True if realizable, False if not, or an error occurs.
     """
     if isinstance(spec, GRSpec):
+        assert not spec.moore
+        assert not spec.plus_one
         struct = translate(spec, 'slugs')
     else:
         struct = spec
@@ -77,6 +79,8 @@ def synthesize(spec, symbolic=False):
     @rtype: C{networkx.DiGraph}
     """
     if isinstance(spec, GRSpec):
+        assert not spec.moore
+        assert not spec.plus_one
         struct = translate(spec, 'slugs')
     else:
         struct = spec

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -1020,7 +1020,7 @@ def synthesize_many(specs, ts=None, ignore_init=None,
 def synthesize(
     option, specs, env=None, sys=None,
     ignore_env_init=False, ignore_sys_init=False,
-    bool_states=False, bool_actions=False, rm_deadends=True
+    rm_deadends=True
 ):
     """Function to call the appropriate synthesis tool on the specification.
 
@@ -1090,17 +1090,6 @@ def synthesize(
         contained in sys.
     @type ignore_sys_init: bool
 
-    @param bool_states: deprecated as inefficient
-
-        if True,
-        then use one bool variable for each state.
-        Otherwise use a single integer variable for all states.
-    @type bool_states: bool
-
-    @param bool_actions: model actions using bool variables,
-        otherwise use integers.
-    @type bool_actions: bool
-
     @param rm_deadends: return a strategy that contains no terminal states.
     @type rm_deadends: bool
 
@@ -1112,9 +1101,7 @@ def synthesize(
     specs = _spec_plus_sys(
         specs, env, sys,
         ignore_env_init,
-        ignore_sys_init,
-        bool_states,
-        bool_actions)
+        ignore_sys_init)
     if option == 'gr1c':
         strategy = gr1c.synthesize(specs)
     elif option == 'slugs':
@@ -1154,9 +1141,7 @@ def synthesize(
 
 def is_realizable(
     option, specs, env=None, sys=None,
-    ignore_env_init=False, ignore_sys_init=False,
-    bool_states=False,
-    bool_actions=False
+    ignore_env_init=False, ignore_sys_init=False
 ):
     """Check realizability.
 
@@ -1164,8 +1149,7 @@ def is_realizable(
     """
     specs = _spec_plus_sys(
         specs, env, sys,
-        ignore_env_init, ignore_sys_init,
-        bool_states, bool_actions)
+        ignore_env_init, ignore_sys_init)
     if option == 'gr1c':
         r = gr1c.check_realizable(specs)
     elif option == 'slugs':
@@ -1190,8 +1174,7 @@ def is_realizable(
 
 def _spec_plus_sys(
     specs, env, sys,
-    ignore_env_init, ignore_sys_init,
-    bool_states, bool_actions
+    ignore_env_init, ignore_sys_init
 ):
     if sys is not None:
         if hasattr(sys, 'state_varname'):
@@ -1202,8 +1185,8 @@ def _spec_plus_sys(
             statevar = 'loc'
         sys_formula = sys_to_spec(
             sys, ignore_sys_init,
-            bool_states=bool_states,
-            bool_actions=bool_actions,
+            bool_states=False,
+            bool_actions=False,
             statevar=statevar)
         specs = specs | sys_formula
         logger.debug('sys TS:\n' + str(sys_formula.pretty()) + _hl)
@@ -1216,8 +1199,8 @@ def _spec_plus_sys(
             statevar = 'eloc'
         env_formula = env_to_spec(
             env, ignore_env_init,
-            bool_states=bool_states,
-            bool_actions=bool_actions,
+            bool_states=False,
+            bool_actions=False,
             statevar=statevar)
         specs = specs | env_formula
         logger.debug('env TS:\n' + str(env_formula.pretty()) + _hl)

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -1188,6 +1188,16 @@ def _spec_plus_sys(
             bool_states=False,
             bool_actions=False,
             statevar=statevar)
+        # consider sys just a formula,
+        # not a synthesis problem
+        # so overwrite settings
+        if hasattr(sys, 'moore'):
+            cp = sys
+        else:
+            cp = specs
+        sys_formula.moore = cp.moore
+        sys_formula.plus_one = cp.plus_one
+        sys_formula.qinit = cp.qinit
         specs = specs | sys_formula
         logger.debug('sys TS:\n' + str(sys_formula.pretty()) + _hl)
     if env is not None:
@@ -1202,6 +1212,13 @@ def _spec_plus_sys(
             bool_states=False,
             bool_actions=False,
             statevar=statevar)
+        if hasattr(env, 'moore'):
+            cp = env
+        else:
+            cp = specs
+        env_formula.moore = cp.moore
+        env_formula.plus_one = cp.plus_one
+        env_formula.qinit = cp.qinit
         specs = specs | env_formula
         logger.debug('env TS:\n' + str(env_formula.pretty()) + _hl)
     logger.info('Overall Spec:\n' + str(specs.pretty()) + _hl)

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -1159,6 +1159,8 @@ def is_realizable(
         r = slugs.check_realizable(specs)
     elif option == 'gr1py':
         r = gr1py.check_realizable(specs)
+    elif option == 'omega':
+        r = omega_int.is_realizable(specs)
     elif option == 'jtlv':
         r = jtlv.check_realizable(specs)
     else:

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -1024,6 +1024,26 @@ def synthesize(
 ):
     """Function to call the appropriate synthesis tool on the specification.
 
+    There are three attributes of C{specs} that define what
+    kind of controller you are looking for:
+
+    1. C{moore}: What information the controller knows when deciding the next
+       values of controlled variables:
+        - Moore: can read current state,
+          but not next environment variable values, or
+        - Mealy: can read current state and next environment variable values.
+
+    2. C{qinit}: Quantification of initial variable values:
+        Whether all states that satisfy a predicate should be winning,
+        or the initial values of some (or all) the variables is
+        subject to the synthesizer's choice.
+
+    3. C{plus_one}: The form of assume-guarantee specification,
+        i.e., how the system guarantees relate to assumptions about the
+        environment.
+
+    For more details about these attributes, see L{GRSpec}.
+
     The states of the transition system can be either:
 
       - all integers, or


### PR DESCRIPTION
This PR closes #150, #156, #159. The primary changes are:

- update strategy enumeration in `tulip.interfaces.omega` and use `omega >= 0.0.9 < 0.1.0`
- offer `is_realizable` for `interfaces.omega` (and in `synth` too)
- require `omega` as a dependency, installed from PyPI
- replace `gr1c` with `omega` in most tests, and in examples
- clean, address minor bugs, and uniformize style in examples
- update docs to reflect default synthesizer
- modernize docs about installation
- update problem formulation in tutorial, paying attention to first-order specs, and more correct assume-guarantee notation (see below)
- install `dd.cudd` on Travis CI to test all options available in `interfaces.omega`
- API: add attributes `GRSpec.moore, plus_one, qinit` in order to define between different synthesis problems, different forms of assume-guarantee specifications, and choices for quantification of initial conditions (PEP 20: explicit is better than implicit)
- use the aforementioned attributes in synthesis interfaces, tests, and examples.

There are a number of changes in the documentation. A more detailed discussion could be carried about these, but in summary, some main points are:

- we have first-order specifications, so talking about propositions only does not represent `tulip`. (Talking about propositions doesn't represent an untyped logic either, though for the moment we are still in transition to becoming untyped).
- Writing `=>` in assume-guarantee specifications should be avoided. Use `\overset{sr}{\rightarrow}` instead.
- Using primed variables, instead of "next" and "X" is an approach closer to the tools, papers, and simple ways of writing difference equations (that don't mention time).

It had been agreed that I would merge these changes directly into `master`. However, the changes are in some cases extensive, so a review would guard against having forgotten something, or discussion regarding some design choices.