### PR TITLE
Matlabsim

### DIFF
--- a/contrib/matlabsim/discrete_example/discrete.py
+++ b/contrib/matlabsim/discrete_example/discrete.py
@@ -50,7 +50,7 @@ specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                     env_safe, sys_safe, env_prog, sys_prog)
 
 # Controller synthesis
-ctrl = synth.synthesize(specs, sys=sys, solver='gr1c')
+ctrl = synth.synthesize(specs, sys=sys, solver='omega')
 
 # Generate a MATLAB script that generates a Mealy Machine
 tomatlab.export('robot_discrete.mat', ctrl)

--- a/contrib/matlabsim/discrete_example/load_discrete.m
+++ b/contrib/matlabsim/discrete_example/load_discrete.m
@@ -2,6 +2,7 @@
 matfile = 'robot_discrete.mat';
 timestep = 1;
 modelname = 'Robot_Discrete';
+systype = 'is_discrete';
 
 % Load the model
 load_tulip;

--- a/contrib/matlabsim/load_tulip.m
+++ b/contrib/matlabsim/load_tulip.m
@@ -106,9 +106,11 @@ for i = 1:num_inputs
     end
 
     % Replace value in MPTsys object
-    num_modes = length(MPTsys);
-    for j = 1:num_modes
-        MPTsys(j).env_act = input_value_map(MPTsys(j).env_act);
+    if is_switched
+        num_modes = length(MPTsys);
+        for j = 1:num_modes
+            MPTsys(j).env_act = input_value_map(MPTsys(j).env_act);
+        end
     end
 end
 
@@ -160,9 +162,11 @@ for i = 1:num_outputs
     end
 
     % Replace value in MPTsys object
-    num_modes = length(MPTsys);
-    for j = 1:num_modes
-        MPTsys(j).sys_act = output_value_map(MPTsys(j).sys_act);
+    if is_switched
+        num_modes = length(MPTsys);
+        for j = 1:num_modes
+            MPTsys(j).sys_act = output_value_map(MPTsys(j).sys_act);
+        end
     end
 end
 
@@ -243,9 +247,25 @@ end
 num_transitions = length(TS.transitions);
 transition_handles = cell(1, num_transitions);
 for ind = 1:num_transitions
-    start_state_index = double(TS.transitions{ind}.start_state) + 1;
-    end_state_index = double(TS.transitions{ind}.end_state) + 1;
+    start_state_index = double(TS.transitions{ind}.start_state);
+    end_state_index = double(TS.transitions{ind}.end_state);
     transition_handles{ind} = Stateflow.Transition(mealy_machine);
+    
+    % Look for the start state by name
+    for i = 1:num_states
+        if(~isempty(find(TS.states{i}.name == start_state_index)))
+            start_state_index = i;
+            break;
+        end;
+    end;
+    % Look for the end state by name
+    for i = 1:num_states
+        if(~isempty(find(TS.states{i}.name == end_state_index)))
+            end_state_index   = i;
+            break;
+        end;
+    end;
+    
     transition_handles{ind}.Source = state_handles{start_state_index};
     transition_handles{ind}.Destination = state_handles{end_state_index};
 
@@ -254,6 +274,15 @@ for ind = 1:num_transitions
     for jnd = 1:num_inputs
         input_name = input_handles{jnd}.Name;
         input_value = eval(['TS.transitions{ind}.inputs.' input_name]);
+        
+        % Change values to integers
+        if(strcmp(input_value,'False'))
+            input_value = 0;
+        elseif(strcmp(input_value,'True'))
+            input_value = 1;
+        else
+        end;
+        
         label_string = [label_string, '(', input_name '==' ...
             num2str(input_value) ')', '&&'];
     end
@@ -261,6 +290,15 @@ for ind = 1:num_transitions
     for jnd = 1:num_outputs
         output_name = output_handles{jnd}.Name;
         output_value = eval(['TS.transitions{ind}.outputs.' output_name]);
+        
+        % Change values to integers
+        if(strcmp(output_value,'False'))
+            output_value = 0;
+        elseif(strcmp(output_value,'True'))
+            output_value = 1;
+        else
+        end;
+        
         label_string = [label_string output_name '=' num2str(output_value) ';'];
     end
     label_string = [label_string '}'];
@@ -271,29 +309,41 @@ end
 num_init_transitions = length(TS.init_trans);
 init_handles = cell(1, num_init_transitions);
 for ind = 1:num_init_transitions
-    init_state_index = double(TS.init_trans{ind}.state) + 1;
+    init_state_index = double(TS.init_trans{ind}.state);
     init_handles{ind} = Stateflow.Transition(mealy_machine);
+    
+    % Look for the initial state by name
+    for i = 1:num_states
+        if(~isempty(find(TS.states{i}.name == init_state_index)))
+            init_state_index = i;
+            break;
+        end;
+    end;
+    
     init_handles{ind}.Destination = state_handles{init_state_index};
-    init_handles{ind}.DestinationOClock = 9;
-    init_handles{ind}.SourceEndPoint = ...
-        [state_handles{init_state_index}.Position(1) - 30, ...
-         state_handles{init_state_index}.Position(2) + 25];
-    init_handles{ind}.MidPoint = ...
-        [state_handles{init_state_index}.Position(1) - 15, ...
-         state_handles{init_state_index}.Position(2) + 25];
+    init_handles{ind}.Source = state_handles{length(state_handles)};
 
     % Label string on initial transitions
     label_string = '[';
     for jnd = 1:num_inputs
         input_name = input_handles{jnd}.Name;
         input_value = eval(['TS.init_trans{ind}.inputs.' input_name]);
+        
+        % Change values to integers
+        if(strcmp(input_value,'False'))
+            input_value = 0;
+        elseif(strcmp(input_value,'True'))
+            input_value = 1;
+        else
+        end;
+        
         label_string = [label_string, '(', input_name '==' ...
                         num2str(input_value) ')', '&&'];
     end
 
     % Add current location to inputs if system is continuous
     if is_continuous
-        current_loc = num2str(double(TS.init_trans{ind}.start_loc));
+        current_loc = num2str(double(0));
         label_string = [label_string '(current_loc==' current_loc ')]{'];
     else
         label_string = [label_string(1:end-2) ']{'];
@@ -303,6 +353,15 @@ for ind = 1:num_init_transitions
     for jnd = 1:num_outputs
         output_name = output_handles{jnd}.Name;
         output_value = eval(['TS.init_trans{ind}.outputs.' output_name]);
+        
+        % Change values to integers
+        if(strcmp(output_value,'False'))
+            output_value = 0;
+        elseif(strcmp(output_value,'True'))
+            output_value = 1;
+        else
+        end;
+        
         label_string = [label_string output_name '=' num2str(output_value) ';'];
     end
     label_string = [label_string '}'];
@@ -310,7 +369,38 @@ for ind = 1:num_init_transitions
     init_handles{ind}.LabelString = label_string;
 end
 
+% Add unconditional transition to initial state
+%-------------------------------------------------------------------------------
+UnCond_handles = cell(1, 1);
+UnCond_handles = Stateflow.Transition(mealy_machine);
 
+UnCond_handles.Destination = state_handles{length(state_handles)};
+UnCond_handles.DestinationOClock = 9;
+UnCond_handles.SourceEndPoint = ...
+    [state_handles{length(state_handles)}.Position(1) - 30, ...
+     state_handles{length(state_handles)}.Position(2) + 25];
+UnCond_handles.MidPoint = ...
+    [state_handles{length(state_handles)}.Position(1) - 15, ...
+     state_handles{length(state_handles)}.Position(2) + 25];
+
+% Label string on initial transitions
+label_string = '[]{';
+
+% Initial outputs
+for jnd = 1:num_outputs
+    output_name = output_handles{jnd}.Name;
+    output_value = eval(['TS.init_trans{1}.outputs.' output_name]);
+    if(strcmp(output_value,'False'))
+        output_value = 0;
+    elseif(strcmp(output_value,'True'))
+        output_value = 1;
+    else
+    end;
+    label_string = [label_string output_name '=' num2str(output_value) ';'];
+end
+label_string = [label_string '}'];
+
+UnCond_handles.LabelString = label_string;
 
 % RHC blocks for continuous systems
 %-------------------------------------------------------------------------------

--- a/contrib/matlabsim/tomatlab.py
+++ b/contrib/matlabsim/tomatlab.py
@@ -209,16 +209,13 @@ def export_mealy(mealy_machine, is_continuous):
     node_to_loc = dict()
     for _, v, label in mealy_machine.edges(data=True):
         node_to_loc[v] = label['loc']
+    node_to_loc[SINIT] = SINIT
     # all nodes must have incoming edges, except SINIT
     n = len(node_to_loc)
     n_ = len(mealy_machine)
-    assert n + 1 == n_, (n, n_)  # some root node != SINIT
     # Export states as a list of dictionaries
     state_list = list()
     for u in mealy_machine.nodes():
-        if u == SINIT:
-            print('Skipping state "{s}".'.format(s=SINIT))
-            continue
         state_dict = dict(name=u)
         # For a continuous system, export the 'loc' variable
         if is_continuous:
@@ -252,11 +249,8 @@ def export_mealy(mealy_machine, is_continuous):
     # Initial states are the states that have transitions from SINIT. Initial
     # transitions (for the purposes of execution in Stateflow), are the
     # transitions coming from the states that transition from SINIT.
-    init_nodes = mealy_machine.successors(SINIT)
-    assert init_nodes, init_nodes
     init_trans = list()
-    for u, v, label in mealy_machine.edges(init_nodes, data=True):
-        assert u != SINIT, u
+    for u, v, label in mealy_machine.edges(SINIT, data=True):
         assert v != SINIT, v
         trans_dict = dict(
             state=v,

--- a/contrib/matlabsim/tomatlab.py
+++ b/contrib/matlabsim/tomatlab.py
@@ -1,14 +1,17 @@
-"""
+"""Export hybrid controller to Matlab.
+
 Only supports closed-loop and non-conservative simulation.
 """
-from tulip import hybrid, abstract
+import numpy
 import polytope
 import scipy.io
-import numpy
+from tulip import abstract
+from tulip import hybrid
 
-def export(filename, mealy_machine, system_dynamics=None, abstraction=None,
-    disc_params=None, R=None, r=None, Q=None, mid_weight=None):
 
+def export(
+        filename, mealy_machine, system_dynamics=None, abstraction=None,
+        disc_params=None, R=None, r=None, Q=None, mid_weight=None):
     """Creates two matlab files. One is a script that generates a Simulink model
     that contains a Stateflow Chart of the Mealy Machine, a block that contains
     a get_input function, a block that maps continuous state to discrete state,
@@ -20,26 +23,26 @@ def export(filename, mealy_machine, system_dynamics=None, abstraction=None,
     @param filename: String containing name of the .mat file to be created.
     @rtype: None
     """
-
     # Check whether we're discrete or continuous
-    if ((system_dynamics is None) and (abstraction is None) and
-        (disc_params is None)):
+    if (
+            (system_dynamics is None) and
+            (abstraction is None) and
+            (disc_params is None)):
         is_continuous = False
-    elif ((system_dynamics is not None) and (abstraction is not None) and
-          (disc_params is not None)):
+    elif (
+            (system_dynamics is not None) and
+            (abstraction is not None) and
+            (disc_params is not None)):
         is_continuous = True
     else:
         raise StandardError('Cannot tell whether system is continuous or ' +
             'discrete. Please specify dynamics and abstraciton and ' +
             'discretization parameters or none at all.')
-
-    output = {}
+    output = dict()
     output['is_continuous'] = is_continuous
-
     # Only export dynamics and abstraction and control weights if the system is
     # continuous
     if is_continuous:
-
         # Export system dynamics, get state and input dimension
         if isinstance(system_dynamics, hybrid.LtiSysDyn):
             dynamics_output = lti_export(system_dynamics)
@@ -54,10 +57,9 @@ def export(filename, mealy_machine, system_dynamics=None, abstraction=None,
         elif isinstance(system_dynamics, hybrid.SwitchedSysDyn):
             dynamics_output = switched_export(system_dynamics)
             dynamics_output['type'] = 'SwitchedSysDyn'
-
             # getting state and input dimension by looking at size of the A and
             # B matrices of one of the PWA subsystems
-            pwa_systems = system_dynamics.dynamics.values()
+            pwa_systems = list(system_dynamics.dynamics.values())
             pwa_system = pwa_systems[0]
             state_dimension = numpy.shape(pwa_system.list_subsys[0].A)[1]
             input_dimension = numpy.shape(pwa_system.list_subsys[0].B)[1]
@@ -65,7 +67,6 @@ def export(filename, mealy_machine, system_dynamics=None, abstraction=None,
             raise TypeError(str(type(system_dynamics)) +
                 ' is not a supported type of system dynamics.')
         output['system_dynamics'] = dynamics_output
-
         # Control weights. Set default values if needed.
         if R is None:
             R = numpy.zeros([state_dimension, state_dimension])
@@ -75,16 +76,14 @@ def export(filename, mealy_machine, system_dynamics=None, abstraction=None,
             Q = numpy.eye(input_dimension)
         if mid_weight is None:
             mid_weight = 3
-
-        control_weights = {}
-        control_weights['state_weight'] = R
-        control_weights['input_weight'] = Q
-        control_weights['linear_weight'] = r
-        control_weights['mid_weight'] = mid_weight
+        control_weights = dict(
+            state_weight=R,
+            input_weight=Q,
+            linear_weight=r,
+            mid_weight=mid_weight)
         output['control_weights'] = control_weights
-
         # Simulation parameters; insert default discretization values if needed
-        sim_params = {}
+        sim_params = dict()
         try:
             sim_params['horizon'] = disc_params['N']
         except KeyError:
@@ -102,63 +101,49 @@ def export(filename, mealy_machine, system_dynamics=None, abstraction=None,
                 raise ValueError('MATLAB interface does not suport ' +
                                  'conservative simulation')
         output['simulation_parameters'] = sim_params
-
         # Abstraction
         output['abstraction'] = export_locations(abstraction)
-
-
     # Export the simulink model
     output['TS'] = export_mealy(mealy_machine, is_continuous)
-
     # Save file
     scipy.io.savemat(filename, output, oned_as='column')
 
 
-
 def lti_export(ltisys):
     """Saves a LtiSysDyn as a Matlab struct."""
-
-    output = {}
-    output['A'] = ltisys.A
-    output['B'] = ltisys.B
-    output['E'] = ltisys.E
-    output['K'] = ltisys.K
-    output['domain'] = poly_export(ltisys.domain)
-    output['Uset'] = poly_export(ltisys.Uset)
-    output['Wset'] = poly_export(ltisys.Wset)
-
+    output = dict(
+        A=ltisys.A,
+        B=ltisys.B,
+        E=ltisys.E,
+        K=ltisys.K,
+        domain=poly_export(ltisys.domain),
+        Uset=poly_export(ltisys.Uset),
+        Wset=poly_export(ltisys.Wset))
     return output
 
 
 def pwa_export(pwasys):
-
-    output = {}
-    output['domain'] = poly_export(pwasys.domain)
-    ltisystems = []
-    for subsystem in pwasys.list_subsys:
-        ltisystems.append(lti_export(subsystem))
-    output['subsystems'] = ltisystems
-
-    return output
+    """Return piecewise-affine system as Matlab struct."""
+    ltisystems = [lti_export(sub) for sub in pwasys.list_subsys]
+    return dict(
+        domain=poly_export(pwasys.domain),
+        subsystems=ltisystems)
 
 
 def switched_export(switchedsys):
-
-    output = {}
-    output['disc_domain_size'] = list(switchedsys.disc_domain_size)
-    output['cts_ss'] = poly_export(switchedsys.cts_ss)
-
-    dynamics = []
+    """Return switched system as Matlab struct."""
+    dynamics = list()
     for label, system in switchedsys.dynamics.items():
-        system_dict = {}
-        system_dict['env_act'] = label[0]
-        system_dict['sys_act'] = label[1]
-        system_dict['pwasys'] = pwa_export(system)
+        env_act, sys_act = label
+        system_dict = dict(
+            env_act=env_act,
+            sys_act=sys_act,
+            pwasys=pwa_export(system))
         dynamics.append(system_dict)
-
-    output['dynamics'] = dynamics
-
-    return output
+    return dict(
+        disc_domain_size=list(switchedsys.disc_domain_size),
+        cts_ss=poly_export(switchedsys.cts_ss),
+        dynamics=dynamics)
 
 
 def poly_export(poly):
@@ -167,12 +152,9 @@ def poly_export(poly):
     @param poly: L{Polytope} that will be exported.
     @return output: dictionary containing fields of poly
     """
-
-    output = {}
-    if poly is not None:
-        output['A'] = poly.A
-        output['b'] = poly.b
-    return output
+    if poly is None:
+        return dict()
+    return dict(A=poly.A, b=poly.b)
 
 
 def reg_export(reg):
@@ -181,12 +163,7 @@ def reg_export(reg):
     @type reg: L{Region}
     @return output: a dictionary containing a list of polytopes.
     """
-    output = {}
-    poly_list = []
-    for poly in reg.list_poly:
-        poly_list.append(poly_export(poly))
-    output['list_poly'] = poly_list
-    return output
+    return dict(list_poly=[poly_export(p) for p in reg.list_poly])
 
 
 def export_locations(abstraction):
@@ -194,34 +171,27 @@ def export_locations(abstraction):
 
     @type abstraction: L{AbstractPwa} or L{AbstractSwitched}
     @rtype output: dictionary"""
-
-    output = {}
-
-    location_list = []
-    for index, region in enumerate(abstraction.ppp.regions):
-        location_dict = {}
-        reg_dict = reg_export(region)
-        location_dict['region'] = reg_dict
-        location_dict['index'] = index
-        location_list.append(location_dict)
-
-    output['abstraction'] = location_list
-
-    return output
+    location_list = list()
+    for i, region in enumerate(abstraction.ppp.regions):
+        d = dict(
+            region=reg_export(region),
+            index=i)
+        location_list.append(d)
+    return dict(abstraction=location_list)
 
 
 def export_mealy_io(variables, values):
-    """
+    """Return declarations of variable types.
+
     @rtype: list of dict
     """
-
-    var_list = []
-    for ind, variable in enumerate(variables):
-        var_dict = {}
-        var_dict['name'] = variable
-        var_dict['values'] = list(values[ind])
-        var_list.append(var_dict)
-    return var_list
+    vrs = list()
+    for i, var in enumerate(variables):
+        d = dict(
+            name=var,
+            values=list(values[i]))
+        vrs.append(d)
+    return vrs
 
 
 def export_mealy(mealy_machine, is_continuous):
@@ -234,83 +204,65 @@ def export_mealy(mealy_machine, is_continuous):
 
     @rtype: dict
     """
-
-    output = {}
-
-    # States will be exported as a list of dictionaries
-    state_list = []
-    for state_tuple in mealy_machine.states.find():
-
-        # Do not export Sinit state
-        if state_tuple[0] == 'Sinit':
+    SINIT = 'Sinit'
+    # map from Mealy nodes to value of variable "loc"
+    node_to_loc = dict()
+    for _, v, label in mealy_machine.edges(data=True):
+        node_to_loc[v] = label['loc']
+    # all nodes must have incoming edges, except SINIT
+    n = len(node_to_loc)
+    n_ = len(mealy_machine)
+    assert n + 1 == n_, (n, n_)  # some root node != SINIT
+    # Export states as a list of dictionaries
+    state_list = list()
+    for u in mealy_machine.nodes():
+        if u == SINIT:
+            print('Skipping state "{s}".'.format(s=SINIT))
             continue
-
-        state_dict = {}
-        state_dict['name'] = state_tuple[0]
-
+        state_dict = dict(name=u)
         # For a continuous system, export the 'loc' variable
         if is_continuous:
-            state_dict['loc'] = state_tuple[1]['loc']
-
+            state_dict.update(loc=node_to_loc[u])
         state_list.append(state_dict)
-    output['states'] = state_list
-
+    output = dict(states=state_list)
     # Get list of environment and system variables
     env_vars = mealy_machine.inputs.keys()
-    env_values = mealy_machine.inputs.values()
+    env_values = list(mealy_machine.inputs.values())
     sys_vars = mealy_machine.outputs.keys()
-    sys_values = mealy_machine.outputs.values()
-    #output['inputs'] = env_vars
-    #output['outputs'] = sys_vars
+    sys_values = list(mealy_machine.outputs.values())
     output['inputs'] = export_mealy_io(env_vars, env_values)
     output['outputs'] = export_mealy_io(sys_vars, sys_values)
-
     # Transitions will be exported as a 2D list of dictionaries. The only
     # purpose of this block here is to separate the inputs from the outputs to
     # make the MATLAB code easier to write
-    transitions = []
-    for transition_tuple in mealy_machine.transitions.find():
-
-        # Ignore transitions from Sinit
-        if transition_tuple[0] == 'Sinit':
+    transitions = list()
+    for u, v, label in mealy_machine.edges(data=True):
+        if u == SINIT:
             continue
-
-        transition_vals = transition_tuple[2]
-        transition_inputs = { var: str(transition_vals[var])
-                              for var in env_vars }
-        transition_outputs = { var: str(transition_vals[var])
-                               for var in sys_vars }
-        transition_dict = {}
-        transition_dict['start_state'] = transition_tuple[0]
-        transition_dict['end_state'] = transition_tuple[1]
-        transition_dict['inputs'] = transition_inputs
-        transition_dict['outputs'] = transition_outputs
+        assert v != SINIT, v
+        evals = {var: str(label[var]) for var in env_vars}
+        svals = {var: str(label[var]) for var in sys_vars}
+        transition_dict = dict(
+            start_state=u,
+            end_state=v,
+            inputs=evals,
+            outputs=svals)
         transitions.append(transition_dict)
     output['transitions'] = transitions
-
-
-    # Initial states are the states that have transitions from Sinit. Initial
+    # Initial states are the states that have transitions from SINIT. Initial
     # transitions (for the purposes of execution in Stateflow), are the
-    # transitions coming from the states that transition from Sinit.
-    Sinit_transitions = mealy_machine.transitions.find(from_states=['Sinit'])
-    initial_states = [ trans[1] for trans in Sinit_transitions ]
-    initial_transitions = mealy_machine.transitions.find(
-        from_states=initial_states)
-    initial_trans = []
-    for init_transition in initial_transitions:
-
-        transition_vals = init_transition[2]
-
-        trans_dict = {}
-        trans_dict['state'] = init_transition[1]
-        trans_dict['inputs'] = { var: str(transition_vals[var])
-                                 for var in env_vars }
-        trans_dict['outputs'] = { var: str(transition_vals[var])
-                                  for var in sys_vars }
-
-        orig_state = init_transition[0]
-        trans_dict['start_loc'] =  mealy_machine.states[orig_state]['loc']
-        initial_trans.append(trans_dict)
-    output['init_trans'] = initial_trans
-
+    # transitions coming from the states that transition from SINIT.
+    init_nodes = mealy_machine.successors(SINIT)
+    assert init_nodes, init_nodes
+    init_trans = list()
+    for u, v, label in mealy_machine.edges(init_nodes, data=True):
+        assert u != SINIT, u
+        assert v != SINIT, v
+        trans_dict = dict(
+            state=v,
+            inputs={var: str(label[var]) for var in env_vars},
+            outputs={var: str(label[var]) for var in sys_vars},
+            start_loc=node_to_loc[u])
+        init_trans.append(trans_dict)
+    output['init_trans'] = init_trans
     return output


### PR DESCRIPTION
"tomatlab.py"

Avoid disposal of initial transitions:
I proposed this change so that the transition from the 'Sinit' state to initial nodes are considered in the exportation as well. The previous code recreate transitions from successors node of 'Sinit' (already considered in the complete transition exportation) to their successors, which cause redundant transitions. In the proposed code 'Sinit' is created and transitions  from it to its successors are considered as 'init_trans'.

"discrete.py"

This modifications should be done for all examples:
It seems that gr1c rises an error in Matlab code (In particular when after executing the following [line](https://github.com/tulip-control/tulip-control/blob/e4258ac28a093e4c8c39099daeeff8238d84a30f/contrib/matlabsim/load_tulip.m#L246) ). As gr1c gives a memory position as names for states, in the mentioned line the state will have naming of an array of doubles instead of one double. So I would suggest "omega" instead as it works perfectly.

"load_discrete.m"

This definition is important before calling "load_Tulip", so it runs well and consider only the discrete case.

"load_Tulip.m"

Errors when generating Stateflow:
I was apple to generate the Matlab file and the Stateflow, but I could not run it in Stateflow because of the following error:

1) 
Chart 'TulipController' has unresolved symbols.
I think that the problem comes from the fact that the env. input signal has integer values (e.x. park in discrete example which is build using load_discrete.m to be selected randomly between 0 or 1) . Whereas for the generated TulipController, it takes as input and output, the values of True and False (not the boolean ones of matlab with first minuscule letters). Therefore, a change to the input and output values of TulipController should be done to either be 0s or 1s.
Other option:  change to all minuscule letters ( change of size problem).

2) 
The lines 110..113 and 164..167 belong to the switched case, so they should be surrounded by if.

3) 
Running the simulation with no unconditional transition gives:

Chart 'TulipController' has no unconditional default path to a state.
This may lead to a state inconsistency error during runtime. You can also configure the diagnostic by clicking here.

So lines 372 to 403 are added to create one.

4)
The indexes of the starting and ending states of transitions is set by finding the corresponding states name in the original 'TS.states'.
The reason for this is that naming of states in the original state-machine is not always sequential, whereas naming in state_handles is.  

5) 
Finally, the presence of 'Sinit' and initial transitions from it are considered (after considering the modifications in 'tomatlab.py' to add them to TS structure (.m file)).