### PR TITLE
Treat new form of non-release gr1c version strings

### DIFF
--- a/tulip/interfaces/gr1c.py
+++ b/tulip/interfaces/gr1c.py
@@ -43,7 +43,7 @@ Use the logging module to throttle verbosity.
 """
 from __future__ import print_function
 
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 import logging
 import copy
 import os
@@ -69,7 +69,7 @@ def check_gr1c():
     except OSError:
         return False
     v = v.split()[1]
-    if StrictVersion(v) >= StrictVersion(GR1C_MIN_VERSION):
+    if parse_version(v) >= parse_version(GR1C_MIN_VERSION):
         return True
     return False
 


### PR DESCRIPTION
Since [commit cdc3ec7059ee0a2bf021394d0ac8b7a37a29df0c](https://github.com/tulip-control/gr1c/commit/cdc3ec7059ee0a2bf021394d0ac8b7a37a29df0c), gr1c builds that do not correspond to releases have version strings with "-devel-" and, if available, text of `git describe`.

E.g., with a sourctree that has pending changes, the first line of `gr1c -V` can be

    gr1c 0.13.0-devel-v0.12.0-5-ge633890-dirty

which distutils.version.StrictVersion() does not accept.

In this pull request, I add a conditional branch to tulip.interfaces.gr1c.check_gr1c() that is taken if `'devel'` is found. In it, everything after and including the first "-" is stripped.
