### PR TITLE
Dual-simulation in tulip/abstract/discretization/discretize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,14 @@ script:
   - pip download --no-dependencies dd==0.4.3
   - tar xzf dd-*.tar.gz
   - cd dd-*/
-  - python setup.py install --fetch --cudd
+  - export CUDD_VERSION=3.0.0
+  - export CUDD_GZ=cudd-${CUDD_VERSION}.tar.gz
+  - curl -sSL https://sourceforge.net/projects/cudd-mirror/files/${CUDD_GZ}/download > ${CUDD_GZ}
+  - expr `shasum -a 256 ${CUDD_GZ}|cut -d ' ' -f1`
+    = b8e966b4562c96a03e7fbea239729587d7b395d53cadcc39a7203b49cf7eeb69
+  - tar -xzf ${CUDD_GZ}
+  - python -c 'from download import make_cudd; make_cudd()'
+  - python setup.py install --cudd
   - cd ..
   # optional python packages
   - pip install gr1py

--- a/tests/abstract_test.py
+++ b/tests/abstract_test.py
@@ -249,8 +249,8 @@ def test_abstract_the_dynamics():
 
     ab = abstract.discretize(ppp, sys, plotit=False,
                              save_img=False, **disc_options)
-    assert(ab.ppp.compute_adj())
-    assert(ab.ppp.is_partition())
+    assert ab.ppp.compute_adj()
+    assert ab.ppp.is_partition()
     # ax = ab.plot(show_ts=True, color_seed=0)
     # sys.plot(ax, show_domain=False)
     # print(ab.ts)
@@ -272,7 +272,7 @@ def test_abstract_the_dynamics_dual():
 
     ab = abstract.discretize(ppp, sys, plotit=False,
                              save_img=False, simu_type='dual', **disc_options)
-    assert(ab.ppp.compute_adj())
+    assert ab.ppp.compute_adj()
 
     [sys_dyn, cont_partition, part] = define_dynamics_dual()
     disc_options = {'N': 1, 'trans_length': 1000, 'min_cell_volume': 0.0}

--- a/tests/abstract_test.py
+++ b/tests/abstract_test.py
@@ -212,6 +212,26 @@ def test_abstract_the_dynamics():
 
 test_abstract_the_dynamics.slow = True
 
+def test_abstract_the_dynamics_dual():
+    """test_abstract_the_dynamics using dual-simulation algorithm"""
+    dom = pc.box2poly([[0.0, 10.0], [0.0, 20.0]])
+    ppp = define_partition(dom)
+    sys = define_dynamics(dom)
+    logger.info(sys)
+
+    disc_options = {'N':3, 'trans_length':2, 'min_cell_volume':1.5}
+
+    ab = abstract.discretize(ppp, sys, plotit=False,
+                             save_img=False, simu_type='dual',**disc_options)
+    assert(ab.ppp.compute_adj() )
+    #ax = ab.plot(show_ts=True, color_seed=0)
+    #sys.plot(ax, show_domain=False)
+    #print(ab.ts)
+
+    #self_loops = {i for i,j in ab.ts.transitions() if i==j}
+    #print('self loops at states: ' + str(self_loops))
+
+test_abstract_the_dynamics.slow = True
 
 def test_is_feasible():
     """Difference between attractor and fixed horizon."""
@@ -240,3 +260,4 @@ def drifting_dynamics(dom):
 
 if __name__ == '__main__':
     test_abstract_the_dynamics()
+    test_abstract_the_dynamics_dual()

--- a/tulip/abstract/discretization.py
+++ b/tulip/abstract/discretization.py
@@ -991,7 +991,7 @@ def reachable_within(trans_length, adj_k, adj):
 
     k = 1
     while k < trans_length:
-        adj_k = np.dot(adj_k, adj)
+        adj_k = (np.dot(adj_k, adj)!=0).astype(int)
         k += 1
     adj_k = (adj_k > 0).astype(int)
 


### PR DESCRIPTION
Implementation of dual-simulation algorithm for LTI/hybrid system

- Add dual-simulation algorithm for `tulip/abstract/discretization/discretize`, controlled by a new parameter `simu_type` (maybe should name the parameter 'overlapping' instead?). 
- Add test code for `discretize`. Test the function only on simple examples. Dual-simulation/bi-simulation relationship may not be garuanteed by passing the current test.