### PR TITLE
Filter transition attributes

### DIFF
--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -1266,10 +1266,13 @@ def strategy2mealy(A, spec):
         k: v for k, v in sys_vars.items()
         if isinstance(v, list)})
     mach.states.add_from(A)
+    all_vars = dict(env_vars)
+    all_vars.update(sys_vars)
     # transitions labeled with I/O
     for u in A:
         for v in A.successors(u):
             d = A.nodes[v]['state']
+            d = {k: v for k, v in d.items() if k in all_vars}
             d = _int2str(d, str_vars)
             mach.transitions.add(u, v, attr_dict=None, check=False, **d)
 
@@ -1300,6 +1303,7 @@ def strategy2mealy(A, spec):
         # add edge: Sinit -> u ?
         tmp.update(var_values)
         if eval(isinit, tmp):
+            var_values = {k: v for k, v in var_values.items() if k in all_vars}
             label = _int2str(var_values, str_vars)
             mach.transitions.add(initial_state, u, attr_dict=None, check=False, **label)
             # remember variable values to avoid

--- a/tulip/transys/labeled_graphs.py
+++ b/tulip/transys/labeled_graphs.py
@@ -859,7 +859,7 @@ class LabeledDiGraph(nx.MultiDiGraph):
                         'in the existing types, pass: check = False')
                 raise AttributeError(msg)
             else:
-                msg += '\nAllowed because you passed: check = True'
+                msg += '\nAllowed because you passed: check = False'
                 logger.warning(msg)
         else:
             logger.debug('no untyped keys.')


### PR DESCRIPTION
Address issue #222 by filtering the dictionary of transition attributes before passing it to the method `tulip.transys.labeled_graphs.Transitions.add`.