### PR TITLE
Initial nodes from GR(1) solvers

### DIFF
--- a/tulip/interfaces/gr1c.py
+++ b/tulip/interfaces/gr1c.py
@@ -362,7 +362,7 @@ def load_aut_json(x):
         node_label['state'] = dict([(list(symtab[i].keys())[0],
                                      autjs['nodes'][node_ID]['state'][i])
                                     for i in range(len(symtab))])
-        A.add_node(node_ID, node_label)
+        A.add_node(node_ID, **node_label)
     for node_ID, d in autjs['nodes'].items():
         for to_node in d['trans']:
             A.add_edge(node_ID, to_node)

--- a/tulip/interfaces/gr1c.py
+++ b/tulip/interfaces/gr1c.py
@@ -356,6 +356,7 @@ def load_aut_json(x):
     symtab = autjs['ENV'] + autjs['SYS']
     A.env_vars = dict([list(v.items())[0] for v in autjs['ENV']])
     A.sys_vars = dict([list(v.items())[0] for v in autjs['SYS']])
+    A.initial_nodes = set()
     omit = {'state', 'trans'}
     for node_ID, d in autjs['nodes'].items():
         node_label = {k: d[k] for k in d if k not in omit}
@@ -363,6 +364,8 @@ def load_aut_json(x):
                                      autjs['nodes'][node_ID]['state'][i])
                                     for i in range(len(symtab))])
         A.add_node(node_ID, **node_label)
+        if node_label['initial']:
+            A.initial_nodes.add(node_ID)
     for node_ID, d in autjs['nodes'].items():
         for to_node in d['trans']:
             A.add_edge(node_ID, to_node)

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -135,6 +135,7 @@ def _strategy_to_state_annotated(g, aut):
         h.add_node(u, state=dvars)
     for u, v in g.edges():
         h.add_edge(u, v)
+    h.initial_nodes = set(g.initial_nodes)
     return h
 
 

--- a/tulip/spec/form.py
+++ b/tulip/spec/form.py
@@ -698,7 +698,9 @@ class GRSpec(LTL):
 
         The returned bytecode can be used with C{eval}
         and a C{dict} assigning values to variables.
-        Its value is the conjunction of C{env_init} and C{sys_init}.
+        Its value is the implication
+
+            C{env_init => sys_init}
 
         Use the corresponding python data types
         for the C{dict} values:

--- a/tulip/synth.py
+++ b/tulip/synth.py
@@ -1268,6 +1268,9 @@ def strategy2mealy(A, spec):
     mach.states.add_from(A)
     all_vars = dict(env_vars)
     all_vars.update(sys_vars)
+    u = next(iter(A))
+    strategy_vars = A.nodes[u]['state'].keys()
+    assert set(all_vars).issubset(strategy_vars)
     # transitions labeled with I/O
     for u in A:
         for v in A.successors(u):
@@ -1284,11 +1287,7 @@ def strategy2mealy(A, spec):
     # fix an ordering for keys
     # because tuple(dict.items()) is not safe:
     # https://docs.python.org/2/library/stdtypes.html#dict.items
-    try:
-        u = next(iter(A))
-        keys = A.nodes[u]['state'].keys()
-    except Exception:
-        logger.warning('strategy has no states.')
+    keys = list(all_vars)
     # to store tuples of dict values for fast search
     isinit = spec.compile_init(no_str=True)
     # Mealy reaction to initial env input


### PR DESCRIPTION
These changes include:

- creation of initial machine transitions from the synthesized strategy for
  the GR(1) solvers that return this information as initial nodes of the strategy,
  `gr1c` and `omega` (#186),

- correction of a typo in the docstring of the function
  `tulip.spec.form.compile_init` (#186),

- using specification variables instead of strategy variables when
  checking for multiplicity of initial machine transitions,

- compatibility with `networkx >= 2.0` in the module `tulip.interfaces.gr1c`.