### PR TITLE
`omega` interface update and related changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ scipy
 # easy extras
 omega==0.1.2
 gr1py==0.2.0
-psutil==5.6.7
 
 # extras (uncomment as needed)
 # cvxopt==1.1.7  # for faster polytopic operations

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ def run_setup():
         install_requires=[
             'networkx >= 2.0, <= 2.4',
             'numpy >= 1.7',
-            'omega >= 0.1.2',
+            'omega >= 0.2.0, < 0.3.0',
             'ply >= 3.4, <= 3.10',
             'polytope >= 0.2.1',
             'pydot >= 1.2.0',

--- a/tests/gridworld_test.py
+++ b/tests/gridworld_test.py
@@ -9,7 +9,6 @@ except ImportError:
 import numpy as np
 import tulip.gridworld as gw
 import unittest
-import psutil
 
 from tulip.synth import is_realizable
 

--- a/tests/gridworld_test.py
+++ b/tests/gridworld_test.py
@@ -2,6 +2,10 @@
 from __future__ import division
 from __future__ import print_function
 
+try:
+    from dd import cudd as dd_cudd
+except ImportError:
+    dd_cudd = None
 import numpy as np
 import tulip.gridworld as gw
 import unittest
@@ -150,8 +154,8 @@ class GridWorld_test(object):
     def test_dumploadloop(self):
         assert self.X == gw.GridWorld(self.X.dumps())
 
-    @unittest.skipIf(psutil.virtual_memory().total < 64e9,
-                     "not enough memory available")
+    @unittest.skipIf(dd_cudd is None,
+                     '`dd.cudd` not installed')
     def test_spec_realizable_bool(self):
         spec = self.X.spec(nonbool=False)
         spec.moore = False

--- a/tests/omega_interface_extra_test.py
+++ b/tests/omega_interface_extra_test.py
@@ -22,7 +22,7 @@ log.addHandler(logging.StreamHandler())
 
 def test_synthesis_cudd():
     sp = grspec_1()
-    h = omega_int.synthesize_enumerated_streett(sp, use_cudd=True)
+    h = omega_int.synthesize_enumerated_streett(sp)
     assert h is not None
     n = len(h)
     assert n == 16, n
@@ -33,5 +33,5 @@ def test_is_circular_cudd():
     f.sys_vars['y'] = 'bool'
     f.env_prog = ['y']
     f.sys_prog = ['y']
-    triv = omega_int.is_circular(f, use_cudd=True)
+    triv = omega_int.is_circular(f)
     assert triv, triv

--- a/tulip/interfaces/_inspect.py
+++ b/tulip/interfaces/_inspect.py
@@ -13,6 +13,14 @@ try:
 except ImportError:
     cvxopt_glpk = None
 try:
+    import dd
+except ImportError:
+    dd = None
+try:
+    from dd import cudd as dd_cudd
+except ImportError:
+    dd_cudd = None
+try:
     import scipy
 except ImportError:
     scipy = None
@@ -49,10 +57,19 @@ def print_env():
         'gr1py', gr1py_int.gr1py, 'https://pypi.python.org/pypi/gr1py')
     c.append(s)
     s = _format_python_package_message(
-        'omega', omega_int.omega, 'https://pypi.python.org/pypi/omega')
+        'dd', dd, 'https://pypi.python.org/pypi/dd')
+    c.append(s)
+    if dd_cudd is None:
+        s = (
+            'Could not import Cython module `dd.cudd`.\n'
+            'Can be installed by compiling and linking the Cython bindings '
+            'of `dd` to CUDD.\n')
+    else:
+        s = 'Found Cython module `dd.cudd` as:\n    {dd_cudd}\n.'.format(
+            dd_cudd=dd_cudd)
     c.append(s)
     s = _format_python_package_message(
-        'dd.cudd', omega_int.cudd, 'https://pypi.python.org/pypi/dd')
+        'omega', omega_int.omega, 'https://pypi.python.org/pypi/omega')
     c.append(s)
     s = _format_python_package_message(
         'numpy', numpy, 'https://pypi.python.org/pypi/numpy')

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -17,14 +17,6 @@ import logging
 import time
 
 try:
-    import dd.bdd as _bdd
-except ImportError:
-    _bdd = None
-try:
-    from dd import cudd
-except ImportError:
-    cudd = None
-try:
     import omega
     from omega.logic import bitvector as bv
     from omega.games import gr1

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -154,7 +154,7 @@ def _grspec_to_automaton(g):
                 'unknown variable type: {v}'.format(v=v))
         d[k] = r
     g.str_to_int()
-    
+
     # reverse mapping by `synth.strategy2mealy`
     a.declare_variables(**d)
     a.varlist.update(env=list(g.env_vars.keys()), sys=list(g.sys_vars.keys()))

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -30,7 +30,7 @@ import networkx as nx
 log = logging.getLogger(__name__)
 
 
-def is_realizable(spec, use_cudd=False):
+def is_realizable(spec):
     """Return `True` if, and only if, realizable.
 
     See `synthesize_enumerated_streett` for more details.
@@ -42,11 +42,10 @@ def is_realizable(spec, use_cudd=False):
     return gr1.is_realizable(z, aut)
 
 
-def synthesize_enumerated_streett(spec, use_cudd=False):
+def synthesize_enumerated_streett(spec):
     """Return transducer enumerated as a graph.
 
     @type spec: `tulip.spec.form.GRSpec`
-    @param use_cudd: efficient BDD computations with `dd.cudd`
     @rtype: `networkx.DiGraph`
     """
     aut = _grspec_to_automaton(spec)
@@ -78,11 +77,10 @@ def synthesize_enumerated_streett(spec, use_cudd=False):
     return h
 
 
-def is_circular(spec, use_cudd=False):
+def is_circular(spec):
     """Return `True` if trivial winning set non-empty.
 
     @type spec: `tulip.spec.form.GRSpec`
-    @param use_cudd: efficient BDD computations with `dd.cudd`
     @rtype: `bool`
     """
     aut = _grspec_to_automaton(spec)

--- a/tulip/transys/labeled_graphs.py
+++ b/tulip/transys/labeled_graphs.py
@@ -950,10 +950,6 @@ class LabeledDiGraph(nx.MultiDiGraph):
 
         Notes
         =====
-        1. Argument C{key} has been removed compared to
-           C{networkx.MultiDiGraph.add_edge}, because edges are defined
-           by their labeling, i.e., multiple edges with same labeling
-           are not allowed.
 
         @param check: raise C{AttributeError} if C{attr_dict}
             has untyped attribute keys, otherwise warn


### PR DESCRIPTION
These changes:

- in the module `tulip.interfaces.omega`:
  - remove unused imports of `dd` and `dd.cudd`
  - remove the unused argument `use_cudd`
- add `dd` and `dd.cudd` information to the function `tulip.interfaces._inspect.print_env`
- run the test `gridworld_test.GridWorld_test.test_spec_realizable_bool` if `dd.cudd` is present
- update the docstring of the method `tulip.transys.labeled_graphs.LabeledDiGraph.add_edge`
- in `install_requires` require the version range `omega >= 0.2.0, < 0.3.0`.
