### PR TITLE
API: update interface to `omega >= 0.3.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ networkx==2.4
 scipy
 
 # easy extras
-omega==0.1.2
+omega==0.3.1
 gr1py==0.2.0
 
 # extras (uncomment as needed)

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ def run_setup():
         install_requires=[
             'networkx >= 2.0, <= 2.4',
             'numpy >= 1.7',
-            'omega >= 0.2.0, < 0.3.0',
+            'omega >= 0.3.1, < 0.4.0',
             'ply >= 3.4, <= 3.10',
             'polytope >= 0.2.1',
             'pydot >= 1.2.0',

--- a/tests/dumpsmach_test.py
+++ b/tests/dumpsmach_test.py
@@ -20,6 +20,7 @@ class basic_test(object):
         self.triv = spec.GRSpec(env_vars="x", sys_vars="y",
                                 env_init="x & y", env_prog="x",
                                 sys_init="y", sys_prog="y && x")
+        self.triv.qinit = '\E \A'
         self.triv_M = synth.synthesize(
             self.triv, solver='omega')
 

--- a/tests/synth_test.py
+++ b/tests/synth_test.py
@@ -364,7 +364,7 @@ def test_only_mode_control():
 
     specs = spec.GRSpec(env_vars, sys_vars, env_init, sys_init,
                         env_safe, sys_safe, env_prog, sys_prog)
-
+    specs.qinit = '\E \A'
     r = synth.is_realizable(specs, env=env_sws, ignore_env_init=True)
     assert not r
 

--- a/tulip/interfaces/omega.py
+++ b/tulip/interfaces/omega.py
@@ -57,15 +57,11 @@ def synthesize_enumerated_streett(spec):
     if not gr1.is_realizable(z, aut):
         print('WARNING: unrealizable')
         return None
-    u = gr1.make_streett_transducer(z, yij, xijk, aut)
-    aut.init['env'] = aut.init['impl_env']
-    aut.init['sys'] = aut.init['impl_sys']
-    aut.action['sys'] = u
+    gr1.make_streett_transducer(z, yij, xijk, aut)
     t2 = time.time()
-    assert u != aut.false
-    g = enum.action_to_steps(aut, qinit=aut.qinit)
+    g = enum.action_to_steps(aut, 'env', 'impl', qinit=aut.qinit)
     h = _strategy_to_state_annotated(g, aut)
-    del u, yij, xijk
+    del z, yij, xijk
     t3 = time.time()
     log.info((
         'Winning set computed in {win} sec.\n'

--- a/tulip/spec/form.py
+++ b/tulip/spec/form.py
@@ -277,19 +277,34 @@ class GRSpec(LTL):
 
       - C{qinit}: select quantification of initial values for variables:
 
-        - C{'\A \A'}: forall env forall sys
-          assume C{env_init}
-          C{sys_init} must be empty
+        C{win} below describes the set of winning states.
+        C{internal_init} is the initial condition for the
+        internal strategy variables.
+        C{Op == expr} means operator C{Op} is defined as the expression C{expr}.
 
-        - C{'\A \E'}: forall env exist sys (usually not Moore)
-          assume C{env_init} and require C{sys_init}
+          - C{'\A \A'}: C{forall env_vars:  forall sys_vars:  env_init -> win}.
+            C{sys_init} must be empty or contain true.
+            The strategy enumeration iterates through all assignments that
+            satisfy C{env_init & internal_init}.
 
-        - C{'\E \A'}: exist sys forall env
-          assume C{env_init} and require C{sys_init}
+          - C{'\A \E'}: C{forall env_vars:  exist sys_vars:  form}, where:
+              - C{form == sys_init & (env_init -> win)}  (C{plus_one is True})
+              - C{form == env_init -> (sys_init & win)}  (C{plus_one is False})
+            The strategy enumeration iterates through all assignments that
+            satisfy C{\E sys_vars:  env_init}, and
+            picks assignments that satisfy C{form & internal_init}.
 
-        - C{'\E \E'}: exist env exist sys
-          require C{sys_init}
-          C{env_init} must be empty
+          - C{'\E \A'}: C{exist sys_vars:  forall env_vars:  form}, where:
+              - C{form == sys_init & (env_init -> win)}  (C{plus_one is True})
+              - C{form == env_init -> (sys_init & win)}  (C{plus_one is False})
+            The strategy enumeration picks an assignment that satisfies
+            C{internal_init & \A env_vars:  form} and iterates through
+            all assignments that satisfy C{env_init}.
+
+          - C{'\E \E'}: C{exist env_vars:  exist sys_vars:  sys_init & win}.
+            C{env_init} must be empty or contain true.
+            The strategy enumeration picks an assignment that satisfies
+            C{sys_init & win & internal_init}.
 
       - C{env_vars}: alias for C{input_variables} of L{LTL},
         concerning variables that are determined by the environment.


### PR DESCRIPTION
These changes:

- update the module `tulip.interfaces.omega` to the API of `omega >= 0.3.0`,
  following revision of how initial conditions are interpreted in GR(1) synthesis,
  and where the synthesized strategy is stored in an automaton.

  The interpretation of initial conditions is now closer to the
  [interpretation of initial conditions in `gr1c`](https://github.com/tulip-control/gr1c/blob/043e72e4a0b3623e8f2dc8b3b26cfc896a77da73/doc/spc_format.md#interpretations-of-initial-conditions).

  For reference, the interpretation of initial conditions is described
  - in the updated docstring of the class `tulip.spec.form.GRSpec`
  - in the docstring of the function [`omega.games.gr1._make_init`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/gr1.py#L495-L536)
  - in the docstring of the function [`omega.enumeration.action_to_steps`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/enumeration.py#L43-L56)
    This function is called from `tulip.interfaces.omega.synthesize_enumerated_streett`.

  More details can be found in the implementation of the functions:
  - [`omega.games.gr1._make_init`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/gr1.py#L538-L570)
  - [`omega.games.gr1.is_realizable`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/gr1.py#L406-L469)
  - [`omega.games.enumeration._forall_init`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/enumeration.py#L225-L240)
  - [`omega.games.enumeration._exist_init`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/enumeration.py#L243-L255)
  - [`omega.games.enumeration._forall_exist_init`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/enumeration.py#L258-L284)
  - [`omega.games.enumeration._exist_forall_init`](https://github.com/tulip-control/omega/blob/b9e2db34a8c5e7601630d97fb943801b865dc736/omega/games/enumeration.py#L287-L315)

  For comparison, the previous interpretation of initial conditions can be
  found in `omega == 0.2.1`, in the functions:
  - [`omega.games.gr1.is_realizable`](https://github.com/tulip-control/omega/blob/v0.2.1/omega/games/gr1.py#L401-L491)
  - [`omega.games.gr1._make_init`](https://github.com/tulip-control/omega/blob/v0.2.1/omega/games/gr1.py#L516-L548)
  - [`omega.games.enumeration.action_to_steps`](https://github.com/tulip-control/omega/blob/v0.2.1/omega/games/enumeration.py#L34-L48)
  - [`omega.games.enumeration._forall_init`](https://github.com/tulip-control/omega/blob/v0.2.1/omega/games/enumeration.py#L149-L162)
  - [`omega.games.enumeration._exist_init`](https://github.com/tulip-control/omega/blob/v0.2.1/omega/games/enumeration.py#L165-L177)
  - [`omega.games.enumeration._forall_exist_init`](https://github.com/tulip-control/omega/blob/v0.2.1/omega/games/enumeration.py#L180-L203)
  - [`omega.games.enumeration._exist_forall_init`](https://github.com/tulip-control/omega/blob/v0.2.1/omega/games/enumeration.py#L206-L234)

  The synthesized strategy is stored in `aut.init['impl']` and
  `aut.action['impl']` (using `'impl'` to abbreviate "implementation"), and the system variables and internal variables are stored in `aut.varlist['impl']` (and the corresponding primed identifiers in `aut.varlist["impl'"]`).

- update the docstring of the class `tulip.spec.form.GRSpec` with details
  about initial conditions

- update tests where initial conditions for both environment and system are
  present to use the interpretation `qinit='\E \A'`, instead of the default
  `'\A \A'`, which requires `sys_init` empty or true (as was specified in the
  docstring of the class `tulip.spec.form.GRSpec`).

- require `omega >= 0.3.1, < 0.4.0` in `install_requires`.