### PR TITLE
Fix continuous with simulation example

### DIFF
--- a/examples/continuous_with_simulation.py
+++ b/examples/continuous_with_simulation.py
@@ -90,10 +90,15 @@ print('\n Simulation starts \n')
 T = 100
 # let us pick an environment signal
 randParkSignal = [random.randint(0, 1) for b in range(1, T + 1)]
+
+# Set up parameters for get_input()
+disc_dynamics.disc_params['conservative'] = True
+disc_dynamics.disc_params['closed_loop'] = False
+
 # initialization:
 #     pick initial continuous state consistent with
 #     initial controller state (discrete)
-u, v, edge_data = ctrl.edges('Sinit', data=True)[1]
+u, v, edge_data = list(ctrl.edges('Sinit', data=True))[1]
 s0_part = edge_data['loc']
 init_poly_v = pc.extreme(disc_dynamics.ppp[s0_part][0])
 x_init = sum(init_poly_v) / init_poly_v.shape[0]

--- a/tulip/transys/machines.py
+++ b/tulip/transys/machines.py
@@ -521,7 +521,7 @@ class MealyMachine(Transducer):
         @type lazy: bool
 
         @return: output values and next state.
-        @rtype: (outputs, next_state)
+        @rtype: (next_state, outputs)
           where C{outputs}: C{{'port_name':port_value, ...}}
         """
         if lazy:


### PR DESCRIPTION
This PR, combined with [polytope/PR #56](https://github.com/tulip-control/polytope/pull/56), fixes issue #228 and a couple of other small bugs/enhancements:

* There was a small bug in `polytope` that was generating an error if you tried to run `abstraction.discretize` with `closed_loop=False`.  The original hack was to set `closed_loop=True` on discretization, but this caused problems with the simulation.  With [polytope/PR #56](https://github.com/tulip-control/polytope/pull/56) in place, we can use `closed_loop=False` in both the discretization and in finding the control input.

* Added in the capability to pass the solver to `abstraction.discretize`.  This is used in some examples that we are preparing for the EECI course.

* The call `pc.is_inside(region, x0)` was causing errors with the number of arguments (2 vs 3).  Since we weren't passing a tolerance, I changed this to `x0 in region`.

* Some small docstring and error message fixes.