### PR TITLE
Fix find_controller for target regions with several polytopes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - ./run_tests.py --outofsource --fast hybrid
   # install cvxopt.glpk
   - export CVXOPT_BUILD_GLPK=1
-  - pip install cvxopt==1.1.8
+  - python -c "import setup; setup.install_cvxopt()"
   - python -c "import cvxopt.glpk"
   # install `dd.cudd`
   - pip uninstall --yes dd

--- a/setup.py
+++ b/setup.py
@@ -125,5 +125,31 @@ def run_setup():
               '!' * 65)
 
 
+def install_cvxopt():
+    """Install a version of cvxopt that is compatible with polytope
+    requirements"""
+    import polytope
+    import subprocess
+    import sys
+    ver = polytope.__version__
+    # Download all files for the current version of polytope
+    subprocess.check_call([
+        sys.executable, "-m",
+        "pip", "download",
+        "-d", "temp",
+        "--no-deps",
+        "polytope=={ver}".format(ver=ver)])
+    # Extract the tar archive
+    subprocess.check_call([
+        "tar", "xzf",
+        "temp/polytope-{ver}.tar.gz".format(ver=ver),
+        "-C", "temp"])
+    # Install cvxopt according to requirements file provided by polytope
+    subprocess.check_call([
+        sys.executable, "-m",
+        "pip", "install",
+        "-r", "temp/polytope-{ver}/requirements/extras.txt".format(ver=ver)])
+
+
 if __name__ == '__main__':
     run_setup()

--- a/tests/abstract_test.py
+++ b/tests/abstract_test.py
@@ -314,6 +314,72 @@ def drifting_dynamics(dom):
     return sys
 
 
+def test_find_controller_non_convex():
+    """Test that it is enough that one polytope in the target region is
+     reachable"""
+    # Continuous state space
+    cont_state_space = pc.box2poly([[0., 1.], [0., 2.]])
+
+    # System dynamics (continuous state, discrete time): simple double integrator
+    # but no reversing.
+    h = 1.0
+    A = np.array([[1.0, h], [0., 1.0]])
+    B = np.array([[h ** 2 / 2.0], [h]])
+    E = None
+
+    # Available control, no disturbances. Can brake or accelerate.
+    U = pc.box2poly(np.array([[-1., 1.]]))
+    W = None
+
+    # Construct the LTI system describing the dynamics
+    sys_dyn = hybrid.LtiSysDyn(A, B, E, None, U, W, cont_state_space)
+
+    # Define atomic propositions for relevant regions of state space
+    cont_props = dict()
+    cont_props['target'] = pc.box2poly([[0., 1.], [0., 2.]])
+
+    # Compute the proposition preserving partition of the continuous state space
+    # noinspection PyTypeChecker
+    cont_partition = abstract.prop2part(cont_state_space, cont_props)
+
+    # Abstraction
+    disc_dynamics = abstract.discretize(
+        cont_partition, sys_dyn,
+        closed_loop=False, conservative=True,
+        N=1, min_cell_volume=0.01, plotit=False,
+        simu_type='bi', trans_length=1
+    )
+
+    # Setup a start point and a target point in a region that are problematic
+    c_start_state = np.array([0.5, 0.0])
+    c_end_desired = np.array([1.0, 2.0])
+    # Find the discrete states of the start state and the target region
+    d_start_state = abstract.find_discrete_state(
+        c_start_state, disc_dynamics.ppp)
+    d_end_state = abstract.find_discrete_state(
+        c_end_desired, disc_dynamics.ppp)
+    # Try to find a control policy
+    u = abstract.find_controller.get_input(
+        x0=c_start_state,
+        ssys=sys_dyn,
+        abstraction=disc_dynamics,
+        start=d_start_state,
+        end=d_end_state,
+        ord=1,
+        mid_weight=5)
+    assert 0.5 <= u <= 1.0, "u was " + str(u)
+    # Try to find a control policy in the other direction and ascertain
+    # an error is thrown
+    assert_raises(Exception, abstract.find_controller.get_input,
+                  x0=c_end_desired,
+                  ssys=sys_dyn,
+                  abstraction=disc_dynamics,
+                  start=d_end_state,
+                  end=d_start_state,
+                  ord=1,
+                  mid_weight=5)
+
+
 if __name__ == '__main__':
     test_abstract_the_dynamics()
     test_abstract_the_dynamics_dual()


### PR DESCRIPTION
In `tulip.abstract.find_controller.get_input()`.

The end state when finding a control action between two discrete regions might consist of several polytopes. For some of the polytopes in the target region there might not be a control action that brings the system there. In that case the matrix constructed by get_input_helper will be singular and the LP solver cannot return a solution. This is not a problem unless all polytopes in the end region are unreachable, in which case it seems likely that there is something wrong with the abstraction routine.

For instance, in the following example (as set up in the commit fe6eb342b94465cb37135a4506a9a2a0c1f4ab92) a controller input exists to bring the system from (0.5, 0.0) in region 0 to a point in region 1 (as shown by the arrows). However, there is no such controller input that brings the system to the left polytope of region 1.
![partition](https://user-images.githubusercontent.com/5064967/84991313-a6a6d580-b146-11ea-906d-50fa77b12fed.png)

