### PR TITLE
DOC: recommend paper to cite

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+url: "https://github.com/tulip-control/tulip-control"
+preferred-citation:
+  type: conference-paper
+  title: "Control design for hybrid systems with TuLiP: The Temporal Logic Planning toolbox"
+  collection-title: "Proc. of IEEE Conference on Control Applications (CCA)"
+  year: 2016
+  start: 1030
+  end: 1041
+  authors:
+    - family-names: "Filippidis"
+      given-names: "Ioannis"
+    - family-names: "Dathathri"
+      given-names: "Sumanth"
+    - family-names: "Livingston"
+      given-names: "Scott C."
+    - family-names: "Ozay"
+      given-names: "Necmiye"
+    - family-names: "Murray"
+      given-names: "Richard M."
+  doi: 10.1109/CCA.2016.7587949

--- a/README.rst
+++ b/README.rst
@@ -88,3 +88,10 @@ copying conditions.
 
 When code is modified or re-distributed, the LICENSE file should accompany the code or any subset of it, however small.
 As an alternative, the LICENSE text can be copied within files, if so desired.
+
+If this software is useful to you, we kindly ask that you cite us::
+
+  I. Filippidis, S. Dathathri, S. C. Livingston, N. Ozay and R. M. Murray,
+  "Control design for hybrid systems with TuLiP: The Temporal Logic Planning
+  toolbox," 2016 IEEE Conference on Control Applications (CCA), Buenos Aires,
+  Argentina, 2016, pp. 1030-1041, doi: 10.1109/CCA.2016.7587949.


### PR DESCRIPTION
I just read a paper published this year that cites a paper about Tulip from 13 years ago. Presumably the authors did not know that there is a more recent paper. This pull request seeks to encourage users to cite it.

Note that the conference name ("IEEE Conference on Control Applications (CCA)") is as indicated in IEEExplore at <https://ieeexplore.ieee.org/document/7587949>. However, this is different than in the reference we have in our docs: https://github.com/tulip-control/tulip-control/blob/b983684c92cdd71bbed8c2765a7766b4868ce54f/doc/bib.txt#L38