### PR TITLE
CI: compare commit hash to decide if docs changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,7 @@ jobs:
                 BIN_BRANCH="docs_bin"
                 git fetch origin $BIN_BRANCH
                 git restore --source=origin/$BIN_BRANCH '*.png'
+                make html
             - name: Push built documentation to `git` branch
               run: |
                 DOCS_BRANCH="docs_pages"
@@ -148,6 +149,12 @@ jobs:
                 git fetch origin $DOCS_BRANCH
                 git checkout -b $DOCS_BRANCH
                 git status
+                git clone --filter=blob:none --no-checkout https://github.com/tulip-control/tulip-control.git temporary
+                cd temporary
+                THIS_COMMIT=`git log --pretty=%H -1 origin/main -- doc tulip examples`
+                cd ..
+                echo $THIS_COMMIT > COMMIT
+                git add COMMIT
                 mkdir docs
                 touch docs/.nojekyll
                 cp -R $DOCS_BUILD_ROOT/. docs/
@@ -157,7 +164,7 @@ jobs:
                 committed by GitHub Actions.'
                 # detect changes to the built documentation
                 git diff --exit-code --quiet $DOCS_BRANCH \
-                    origin/$DOCS_BRANCH -- docs \
+                    origin/$DOCS_BRANCH -- COMMIT \
                     || ret=$?
                 if [[ "${ret}" -eq 1 ]]; then
                     echo 'The built documentation changed, \


### PR DESCRIPTION
During review of <https://github.com/tulip-control/tulip-control/pull/256>, I missed that `make html` was removed in https://github.com/tulip-control/tulip-control/commit/14417c5f34df4b238aec707c5e1ca9e26b532043 while the newly added [contrib/ci_deploy_doc.py](https://github.com/tulip-control/tulip-control/blob/b3ba3afe6fb353bd29b3e2985563eb00520b671b/contrib/ci_deploy_doc.py) is not called. As such, documentation CI jobs on `main` branch are now failing.

As noted [in the comments of ci_deploy_doc.py](https://github.com/tulip-control/tulip-control/blob/b3ba3afe6fb353bd29b3e2985563eb00520b671b/contrib/ci_deploy_doc.py#L149), the timestamp added to files will cause diff between previous and new docs files to always be nonempty. In this pull request, I propose to decide whether new docs should be posted according to whether the most recent commit hash involving the `doc/` directory has changed. The only limitation of this approach is to not detect changes that are included in the documentation from outside the `doc/` directory, e.g., via `autoclass` and `autofunction` blocks in [doc/tutorial.rst](https://github.com/tulip-control/tulip-control/blob/b3ba3afe6fb353bd29b3e2985563eb00520b671b/doc/tutorial.rst).

Therefore, I propose we do one of the following:
1. merge this PR,
2. extend this PR to also check whether the `tulip` directory has changed,
3. modify this PR to only add `make html`, such that docs pushes happen on every merge to `main` branch.

In all cases, note that the branch `docs_pages` for GitHub Pages is special, and we can delete it and create a new one as desired to avoid excess blob creation, deploy docs manually, etc.