### PR TITLE
MNT: use `packaging`, instead of `pkg_resources`

### DIFF
--- a/.github/workflows/setup_basic_testing.sh
+++ b/.github/workflows/setup_basic_testing.sh
@@ -43,7 +43,7 @@ pip install dd \
 python setup.py sdist
 pip install dist/tulip-*.tar.gz
 # install test dependencies
-pip install pytest
+pip install pytest packaging
 # diagnostics
 dot -V
 set -o posix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ Homepage = "http://tulip-control.org"
 test = [
     "matplotlib >= 2.0.0",
     "gr1py >= 0.2.0",
+    "packaging >= 25.0",
     "pytest",
     "setuptools >= 39.0.0",
 ]

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -10,8 +10,7 @@ import sys
 import unittest.mock as mock
 
 import git
-import pkg_resources
-from pkg_resources.extern import packaging
+import packaging
 import pytest
 import tulip
 import tulip._version
@@ -71,7 +70,7 @@ def test_git_version(mock_repo):
 
 def assert_pep440(version):
     """Raise `AssertionError` if `version` violates PEP440."""
-    v = pkg_resources.parse_version(version)
+    v = packaging.version.parse(version)
     assert isinstance(v, packaging.version.Version), v
 
 

--- a/tulip/interfaces/gr1c.py
+++ b/tulip/interfaces/gr1c.py
@@ -49,7 +49,6 @@ import errno
 import json
 import logging
 import os
-import pkg_resources as _pkg
 import subprocess
 import tempfile
 import typing as _ty
@@ -86,9 +85,20 @@ def check_gr1c() -> bool:
     except OSError:
         return False
     v = v.split()[1]
-    if _pkg.parse_version(v) >= _pkg.parse_version(GR1C_MIN_VERSION):
+    if _parse_version(v) >= _parse_version(GR1C_MIN_VERSION):
         return True
     return False
+
+
+def _parse_version(
+        version:
+            str
+        ) -> tuple[int, int, int]:
+    """Return version as tuple."""
+    numerals = version.split('.')
+    if len(numerals) != 3:
+        raise ValueError(version)
+    return tuple(map(int, numerals))
 
 
 def _assert_gr1c() -> None:


### PR DESCRIPTION
- In `tests/version_test.py` use the package [`packaging`](https://pypi.org/project/packaging/), instead of [`pkg_resources`](https://setuptools.pypa.io/en/latest/pkg_resources.html) (of `setuptools`), because `pkg_resources` is deprecated.

- Replace usage of `pkg_resources` within `tulip` without adding dependencies.