### PR TITLE
BUG: build parser in `setup.py`, CI: updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,53 +63,6 @@ jobs:
                 # slow hybrid tests, and
                 # alternative game solvers
                 ./run_tests.py --outofsource full
-    static_analysis:
-        name: Static analysis of Python code
-        runs-on: ubuntu-22.04
-        continue-on-error: true
-        strategy:
-            matrix:
-                python-version: [
-                    '3.10',
-                    ]
-        steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
-              with:
-                  python-version: ${{ matrix.python-version }}
-            - name: Install dependencies from PyPI
-              run: |
-                pip install \
-                    --ignore-installed \
-                    --upgrade \
-                        pip \
-                        setuptools \
-                        wheel
-            - name: Create sdist for `tulip`
-              run: |
-                python setup.py sdist
-            - name: Install only `tulip` dependencies
-              run: |
-                pip install dist/tulip-*.tar.gz
-                pip uninstall --yes tulip
-            - name: Install analysis tools
-              run: |
-                pip install \
-                    --upgrade \
-                        pytype
-            - name: Statically analyze `tulip`
-              run: |
-                pytype --tree tulip
-                pytype --unresolved tulip
-                pytype \
-                    -v 1 \
-                    -k \
-                    -j 'auto' \
-                        tulip \
-                        setup.py \
-                        run_tests.py \
-                    -x tulip/interfaces/stormpy.py
     docs:
         name: Build documentation
         runs-on: ubuntu-22.04

--- a/.github/workflows/setup_basic_testing.sh
+++ b/.github/workflows/setup_basic_testing.sh
@@ -8,7 +8,6 @@
 sudo apt update
 sudo apt install \
     gfortran \
-    libatlas-base-dev \
     liblapack-dev \
     libgmp-dev \
     libmpfr-dev \

--- a/.github/workflows/setup_basic_testing.sh
+++ b/.github/workflows/setup_basic_testing.sh
@@ -28,6 +28,7 @@ sudo apt install \
 pip install \
     --ignore-installed \
     --upgrade \
+        build \
         pip \
         setuptools \
         wheel
@@ -39,7 +40,7 @@ pip install \
 pip install dd \
     --no-binary dd
 # install `tulip`
-python setup.py sdist
+python -m build
 pip install dist/tulip-*.tar.gz
 # install test dependencies
 pip install pytest packaging

--- a/.github/workflows/setup_full_testing.sh
+++ b/.github/workflows/setup_full_testing.sh
@@ -4,6 +4,9 @@
 # Prepare for running test collection "full".
 
 
+sudo apt install \
+    curl
+
 # install `cvxopt.glpk`
 export CVXOPT_BUILD_GLPK=1
 #

--- a/.github/workflows/setup_full_testing.sh
+++ b/.github/workflows/setup_full_testing.sh
@@ -89,4 +89,5 @@ which slugs
 pip install gitpython
 #
 # install `stormpy` and its dependencies
-./extern/get-stormpy.sh
+pip install stormpy
+# ./extern/get-stormpy.sh

--- a/contrib/pytype_check.sh
+++ b/contrib/pytype_check.sh
@@ -1,0 +1,23 @@
+# Type checking of `tulip` using `pytype`.
+# Assumes that `tulip` dependencies have been installed.
+
+
+# Install dependencies from PyPI
+pip install --upgrade \
+    pip \
+    setuptools \
+    wheel
+# Install analysis tools
+pip install --upgrade \
+    pytype
+# Statically analyze `tulip`
+pytype --tree tulip
+pytype --unresolved tulip
+pytype \
+    -v 1 \
+    -k \
+    -j 'auto' \
+        tulip \
+        setup.py \
+        run_tests.py \
+    -x tulip/interfaces/stormpy.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = [
+    "ply >= 3.4, <= 3.10",
+    "setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Installation script."""
+import importlib
 import logging
 import subprocess
 import sys
@@ -54,20 +55,23 @@ def run_setup() -> None:
     """Build parser, get version from `git`, install."""
     # Build PLY table, to be installed as tulip package data
     try:
-        import tulip.spec.lexyacc
-        tabmodule = tulip.spec.lexyacc.TABMODULE.split('.')[-1]
+        print('Building parser tables...')
+        lexyacc = import_module_from_file(
+            'lexyacc', 'tulip/spec/lexyacc.py')
+        tabmodule = lexyacc.TABMODULE.split('.')[-1]
         outputdir = 'tulip/spec'
-        parser = tulip.spec.lexyacc.Parser()
+        parser = lexyacc.Parser(ast='building')
         parser.build(
             tabmodule,
             outputdir=outputdir,
             write_tables=True,
             debug=True,
             debuglog=_logger)
-        import tulip.interfaces.ltl2ba
-        tabmodule = tulip.interfaces.ltl2ba.TABMODULE.split('.')[-1]
+        ltl2ba = import_module_from_file(
+            'ltl2ba', 'tulip/interfaces/ltl2ba.py')
+        tabmodule = ltl2ba.TABMODULE.split('.')[-1]
         outputdir = 'tulip/interfaces'
-        parser = tulip.interfaces.ltl2ba.Parser()
+        parser = ltl2ba.Parser()
         parser.build(
             tabmodule,
             outputdir=outputdir,
@@ -75,6 +79,7 @@ def run_setup() -> None:
             debug=True,
             debuglog=_logger)
         plytable_build_failed = False
+        print('Completed building parser tables.')
     except Exception as e:
         tb = ''.join(
             _tb.format_exception(e))
@@ -104,6 +109,20 @@ def run_setup() -> None:
               '    Failed to build PLY table.  ' +
               'Please run setup.py again.' +
               '!' * 65)
+
+
+def import_module_from_file(
+        module_name:
+            str,
+        filepath:
+            str):
+    """Return imported module."""
+    module_spec = importlib.util.spec_from_file_location(
+        module_name, filepath)
+    module = importlib.util.module_from_spec(module_spec)
+    sys.modules[module_name] = module
+    module_spec.loader.exec_module(module)
+    return module
 
 
 def install_cvxopt() -> None:

--- a/tests/transys_mathset_test.py
+++ b/tests/transys_mathset_test.py
@@ -142,7 +142,7 @@ def subset_test():
     assert(s._set == {1,2} )
     assert(not bool(s._list) )
     #s.add(3)
-    return a
+
 
 def powerset_test():
     s = [[1, 2], '3', {'a':1}, 1]
@@ -160,7 +160,7 @@ def powerset_test():
     assert(isinstance(f, PowerSet) )
     assert(f.math_set._set == {1, '3', 6} )
     assert(compare_lists(f.math_set._list, [[1, 2], {'a':1} ] ) )
-    return s
+
 
 class PowerSet_operations_test:
     def setup_method(self):

--- a/tests/transys_ts_test.py
+++ b/tests/transys_ts_test.py
@@ -30,7 +30,6 @@ def ts_test():
     for state in {'s1', 's2', 's3'}:
         assert(ts.states[state]['ap'] == set() )
     _logger.debug(ts)
-    return ts
 
 
 def ba_test():
@@ -52,12 +51,11 @@ def ba_test():
     ba.transitions.add('q0', 'q0', letter=set() )
     _logger.debug(ba)
     ba.save('ba.pdf')
-    return ba
 
 
 def ba_ts_prod_test():
-    ts = ts_test()
-    ba = ba_test()
+    ts = _make_ts()
+    ba = _make_ba()
     ba_ts = trs.products.ba_ts_sync_prod(ba, ts)
     check_prodba(ba_ts)
     ts_ba, persistent = trs.products.ts_ba_sync_prod(ts, ba)
@@ -66,7 +64,6 @@ def ba_ts_prod_test():
     assert(set(ts_ba.states) == states)
     assert(persistent == {('s0', 'q1')} )
     ba_ts.save('prod.pdf')
-    return ba_ts
 
 
 def check_prodba(ba_ts):
@@ -93,11 +90,41 @@ def check_prodba(ba_ts):
     )
 
 def on_the_fly_test():
-    ba = ba_test()
-    ts = ts_test()
+    ba = _make_ba()
+    ts = _make_ts()
     prodba = trs.OnTheFlyProductAutomaton(ba, ts)
     assert(set(prodba.states) == {('s0', 'q1'), ('s1', 'q0')})
     prodba.save('prodba_initialized.pdf')
     prodba.add_all_states()
     check_prodba(prodba)
     prodba.save('prodba_full.pdf')
+
+
+def _make_ts():
+    ts = trs.FTS()
+    states = {'s0', 's1', 's2', 's3'}
+    ts.states.add_from(states)
+    ts.states.initial.add_from({'s0', 's1'})
+    ts.atomic_propositions.add('p')
+    ts.transitions.add_from(
+        [('s0', 's1'), ('s1', 's2'),
+         ('s2', 's3'), ('s3', 's0')])
+    ts.atomic_propositions.add('p')
+    ts.states['s0']['ap'] = {'p'}
+    ts.states['s1']['ap'] = set()
+    ts.states['s2']['ap'] = set()
+    ts.states['s3']['ap'] = set()
+    return ts
+
+
+def _make_ba():
+    ba = trs.BA()
+    ba.atomic_propositions |= {'p'}
+    ba.states.add_from({'q0', 'q1'})
+    ba.states.initial.add('q0')
+    ba.accepting.add('q1')
+    ba.transitions.add('q0', 'q1', letter={'p'})
+    ba.transitions.add('q1', 'q1', letter={'p'})
+    ba.transitions.add('q1', 'q0', letter=set())
+    ba.transitions.add('q0', 'q0', letter=set())
+    return ba

--- a/tulip/interfaces/ltl2ba.py
+++ b/tulip/interfaces/ltl2ba.py
@@ -32,12 +32,10 @@
 """Interface to `ltl2ba`."""
 import logging
 import subprocess
+import typing as _ty
 
-import networkx as nx
 import ply.lex
 import ply.yacc
-
-import tulip.transys as _trs
 
 
 TABMODULE = 'tulip.interfaces.ltl2ba_parsetab'
@@ -222,7 +220,7 @@ class Parser:
                 str
             ) -> tuple[
                 dict[str, str],
-                nx.DiGraph,
+                _ty.Any,  # `networkx.MultiDiGraph`
                 set[str],
                 set[str]]:
         """Return a Buchi automaton from parsing `ltl2ba_output`.
@@ -243,6 +241,7 @@ class Parser:
               the key `"guard"`, with a Boolean
               formula as value (the formula as `str`)
         """
+        import networkx as nx
         self.g = nx.MultiDiGraph()
         # flat is better than nested
         self.initial_nodes = set()
@@ -344,8 +343,7 @@ class Parser:
 
 def ltl2ba(
         formula:
-            str
-        ) -> _trs.BuchiAutomaton:
+            str):  # -> tulip.transys.BuchiAutomaton
     """Convert LTL formula to Buchi Automaton using `ltl2ba`.
 
     @param formula:
@@ -354,6 +352,7 @@ def ltl2ba(
         Buchi automaton whose edges are annotated
         with Boolean formulas as `str`
     """
+    import tulip.transys as _trs
     ltl2ba_out = call_ltl2ba(str(formula))
     parser = ltl2baint.Parser()
     symbols, g, initial, accepting = parser.parse(ltl2ba_out)

--- a/tulip/interfaces/ltl2ba.py
+++ b/tulip/interfaces/ltl2ba.py
@@ -167,9 +167,7 @@ class Parser:
         self.start = 'claim'
         self.tokens = self.lexer.tokens
         self.tabmodule = TABMODULE
-        self.build(
-            write_tables=True,
-            debug=False)
+        self.build()
         self.g = None
         self.initial_nodes = None
         self.accepting_nodes = None

--- a/tulip/spec/lexyacc.py
+++ b/tulip/spec/lexyacc.py
@@ -41,8 +41,6 @@ import warnings
 import ply.lex
 import ply.yacc
 
-import tulip.spec.ast as _ast
-
 
 _logger = logging.getLogger(__name__)
 TABMODULE = 'tulip.spec.ltl_parsetab'
@@ -252,6 +250,8 @@ class Parser:
             ast=None,
             lexer=None):
         if ast is None:
+            import tulip.spec.ast as _ast
+                # enables importing from `setup.py`
             self.ast = _ast.nodes
         else:
             self.ast = ast
@@ -349,8 +349,8 @@ class Parser:
                 str,
             debuglog:
                 logging.Logger |
-                None=None
-            ) -> _ast.NodeSpec:
+                None=None):
+            # ) -> _ast.NodeSpec:
         """Return syntax tree for `formula`.
 
         @param formula:
@@ -484,8 +484,8 @@ class Parser:
 
 def parse(
         formula:
-            str
-        ) -> _ast.NodeSpec:
+            str):
+        # ) -> _ast.NodeSpec:
     warnings.warn(
         'Deprecated: Better to '
         'instantiate a Parser once only.')


### PR DESCRIPTION
These changes include:

- BUG: build parser tables in `setup.py` (was raising a `ModuleNotFoundError` masked by `except Exception`)
- CI: do not run typechecking
- CI: install `stormpy` from PyPI

Typechecking can impose constraints on the code that are not necessary by Python itself. `pytype` development is not continuing <https://github.com/google/pytype>.