### PR TITLE
CI: updates, Python 3.14, BUG: specific token values, REF: `TypeAlias`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         strategy:
             matrix:
-                python-version: ['3.10']
+                python-version: ['3.14']
         steps:
             - uses: actions/checkout@v5
             - name: Install `apt` packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
                 python-version: [
                     '3.10',
                     '3.11',
+                    '3.12',
+                    '3.13',
+                    '3.14',
                     ]
         steps:
             - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     build:
         name: Build
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         strategy:
             matrix:
                 python-version: [
@@ -68,7 +68,7 @@ jobs:
                 ./run_tests.py --outofsource full
     docs:
         name: Build documentation
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         if: github.ref == 'refs/heads/main'
         strategy:
             matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
                     '3.11',
                     ]
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v5
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Define CI directory
@@ -71,7 +71,7 @@ jobs:
             matrix:
                 python-version: ['3.10']
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v5
             - name: Install `apt` packages
               run: |
                 sudo apt update
@@ -79,7 +79,7 @@ jobs:
                     dvipng \
                     texlive-latex-extra \
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies from PyPI

--- a/.github/workflows/setup_basic_testing.sh
+++ b/.github/workflows/setup_basic_testing.sh
@@ -8,6 +8,7 @@
 sudo apt update
 sudo apt install \
     gfortran \
+    libsuitesparse-dev \
     liblapack-dev \
     libgmp-dev \
     libmpfr-dev \
@@ -24,6 +25,9 @@ sudo apt install \
     libz3-dev \
     python3-z3 \
     libhwloc-dev
+    # cvxopt:
+    #    libsuitesparse-dev
+    #    libglpk-dev
 # install dependencies from PyPI
 pip install \
     --ignore-installed \

--- a/contrib/nessainstall/install.sh
+++ b/contrib/nessainstall/install.sh
@@ -346,7 +346,7 @@ fi
 cd tulip-control
 
 if [ "$tulip_develop" = "true" ]; then
-	python setup.py develop
+	pip install -e .
 else
     pip install .
 fi

--- a/contrib/nessainstall/instructions.md
+++ b/contrib/nessainstall/instructions.md
@@ -17,7 +17,7 @@ You can now:
 ```
 mkvirtualenv nessa
 cd ~/nessa`
-python setup.py develop
+pip install -e .
 ```
 
 Then your editor (e.g. `spyder`) will see the docstrings and functions as you work on them

--- a/contrib/xml/xmlio.py
+++ b/contrib/xml/xmlio.py
@@ -161,7 +161,7 @@ def exportXML(
     tree = _export_xml(data, None, tag)
     _make_pretty(tree)
     pretty_string = ET.tostring(tree)
-    xmlfile = open(filename, 'w')
+    xmlfile = open(filename, 'wb')
     xmlfile.write(pretty_string)
     xmlfile.close()
 

--- a/contrib/xml/xmlio.py
+++ b/contrib/xml/xmlio.py
@@ -115,13 +115,13 @@ def _make_pretty(
     tab_string = '\n' + '\t' * indent
     # If a tree has children,
     # put tabs in front of the first child
-    if tree.getchildren():
+    if list(tree):
         if tree.text is not None:
             tree.text = tab_string + tree.text
         else:
             tree.text = tab_string
     # Number of children in the tree
-    N = len(tree.getchildren())
+    N = len(list(tree))
     # Recursively run function on children
     for index, child in enumerate(tree):
         _make_pretty(child, indent=indent + 1)

--- a/contrib/xml/xmlio.py
+++ b/contrib/xml/xmlio.py
@@ -214,7 +214,7 @@ def _import_xml(
     elif nodetype == T_ADJ:
         return _import_adj(node)
     elif nodetype == T_SET:
-        return _import_list(node, type_STR=T_SET)
+        return _import_list(node, type_str=T_SET)
     # Tulip data structures
     elif nodetype == T_POLYTOPE:
         return _import_polytope(node)

--- a/contrib/xml/xmlio.py
+++ b/contrib/xml/xmlio.py
@@ -36,8 +36,6 @@ Contains XML import and export functions,
 so that we can export (and not recompute)
 TuLiP data structures.
 """
-import typing as _ty
-
 import numpy
 import polytope
 import scipy.sparse as _sp
@@ -47,7 +45,7 @@ from tulip import abstract
 import xml.etree.ElementTree as ET
 
 
-_Data: _ty.TypeAlias = (
+_Data = (
     polytope.Polytope |
     polytope.Region |
     abstract.PropPreservingPartition |

--- a/extern/get-stormpy.sh
+++ b/extern/get-stormpy.sh
@@ -90,7 +90,7 @@ echo '64885a0b0abf13aaed542a05ef8e590194b13626dcd07209ec55b41f788c6a56  pycarl.t
     shasum -a 256 -c -
 tar xzf pycarl.tgz
 pushd pycarl-2.2.0
-python3 setup.py develop
+pip3 install -e .
 popd
 
 
@@ -167,5 +167,5 @@ echo '3c59fb8bed69637e7a1e96b9372198a3428b305520108baa3df627a35940762d  stormpy-
     shasum -a 256 -c -
 tar xzf stormpy-stable.tgz
 pushd stormpy-1.8.0
-python3 setup.py develop
+pip3 install -e .
 popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,8 @@ name = "tulip"
 description = "Temporal Logic Planning (TuLiP) Toolbox"
 authors = [{name = "Caltech Control and Dynamical Systems", email = "tulip@tulip-control.org"}]
 readme = "README.rst"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 classifiers = [
-    "License :: OSI Approved :: BSD License",
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",

--- a/tulip/graphics.py
+++ b/tulip/graphics.py
@@ -69,9 +69,9 @@ __all__ = [
 
 
 if _ty.TYPE_CHECKING:
-    _Digraph: _ty.TypeAlias = _gv.Digraph
-    _Axes: _ty.TypeAlias = _mpl.axes.Axes
-    _Figure: _ty.TypeAlias = _mpl.figure.Figure
+    _Digraph = _gv.Digraph
+    _Axes = _mpl.axes.Axes
+    _Figure = _mpl.figure.Figure
 else:
     _Digraph = _utl.get_type(_gv, 'Digraph')
     _Axes = _utl.get_type(_mpl, 'axes.Axes')

--- a/tulip/spec/lexyacc.py
+++ b/tulip/spec/lexyacc.py
@@ -159,36 +159,59 @@ class Lexer:
         t.value = '|'
         return t
 
-    t_NOT = r'''
+    def t_NOT(self, t):
+        r"""
           !
         | \~
-        '''
+        """
+        t.value = '!'
+        return t
+
     t_XOR = r' \^ '
     t_EQUALS = r' = '
         # a declarative language
         # has no assignment
-    t_NEQUALS = r'''
+
+    def t_NEQUALS(self, t):
+        r"""
           !=
         | /=
-        '''
+        """
+        t.value = '!='
+        return t
+
     t_LT = r' < '
-    t_LE = r'''
+
+    def t_LE(self, t):
+        r"""
           <=
         | =<
-        '''
+        """
+        t.value = '<='
+        return t
+
     t_GT = r' >= '
     t_GE = r' > '
     t_LPAREN = r' \( '
     t_RPAREN = r' \) '
     t_NUMBER = r' \d+ '
-    t_IMP = r'''
+
+    def t_IMP(self, t):
+        r"""
           \- >
         | =>
-        '''
-    t_BIMP = r'''
+        """
+        t.value = '->'
+        return t
+
+    def t_BIMP(self, t):
+        r"""
           < \- >
         | <=>
-        '''
+        """
+        t.value = '<->'
+        return t
+
     t_PLUS = r' \+ '
     t_MINUS = r' \- '
     t_TIMES = r' \* '


### PR DESCRIPTION
The changes include:

- CI: test using CPython 3.12, 3.13, 3.14
- CI: install dependencies to build `cvxopt` wheel for Python 3.14
- CI: update versions of GitHub Actions used
- CI: use Ubuntu 24.04 (was 22.04)
- REF: omit `typing.TypeAlias`, which was deprecated in Python 3.12
- REL: use string as value for `project.license` and omit relevant Trove classifier, because it raises a `setuptools` error once `project.license` becomes a string value
- MNT: for editable installs use `pip install -e .` (was `python setup.py develop`)
- BUG: the lexemes `~`, `=>`, `/=`, `=<`, `<=>` propagated beyond the lexer, but instead the values `!`, `->`, `!=`, `<=`, `<->` were expected by later stages. Changed the lexer to set the value in each case to `!`, `->`, `!=`, `<=`, or `<->`.