### PR TITLE
REL: update versions of dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
         strategy:
             matrix:
                 python-version: [
-                    '3.10',
                     '3.11',
                     '3.12',
                     '3.13',

--- a/.github/workflows/setup_full_testing.sh
+++ b/.github/workflows/setup_full_testing.sh
@@ -33,7 +33,9 @@ echo "b8e966b4562c96a03e7fbea23972958\
 # unpack
 tar -xzf ${CUDD_GZ}
 python -c 'from download import make_cudd; make_cudd()'
-python setup.py install --cudd
+pip install --upgrade wheel cython
+export DD_CUDD=1
+pip install . -vvv --use-pep517 --no-build-isolation
 cd tests/
 python -c 'import dd.cudd'
 cd ../..

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "graphviz >= 0.20",
     "networkx >= 2.0",
     "numpy >= 1.24",
-    "omega >= 0.3.1, < 0.4.0",
+    "omega >= 0.4.0",
     "ply >= 3.4, <= 3.10",
     "polytope >= 0.2.1",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dynamic = ["version"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "graphviz >= 0.20",
     "networkx >= 2.0",


### PR DESCRIPTION
- In `setuptools == 82.0.0`, `pkg_resources` has been removed, thus requiring `omega >= 0.4.0`, which requires Python >= 3.11. `tulip` is updated to require Python >= 3.11 and `omega >= 0.4.0`, in order to avoid `pip` attempting to install `omega == 0.3.1` in combination with `setuptools == 82.0.0`, which are incompatible. Python 3.10 is omitted from CI environments.

- How `dd` is built in CI is updated, because `dd >= 0.6.0` requires Python >= 3.11, so it will be installed in all supported Python environments, which enables using environment variables in combination with `pip install` for `dd`. Previously, for Python 3.10 `dd == 0.5.7` was used, thus `python setup.py install` was still used.